### PR TITLE
feat(statblocks_v1): PR12 bounded-context foundation

### DIFF
--- a/Docs/Plans/HANDOFF-pr12-statblock-v1-bounded-context-foundation.md
+++ b/Docs/Plans/HANDOFF-pr12-statblock-v1-bounded-context-foundation.md
@@ -144,13 +144,28 @@ Required:
 - test confirms no Firebase/OpenAI provider is constructed;
 - focused test command exits successfully from a clean environment.
 
-Required focused command (cuts off ancestor `tests/conftest.py`):
+Required focused command (import-isolated and dependency-isolated):
 
 ```bash
-uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+./scripts/run_statblocks_v1_tests.sh
 ```
 
-The exact command must be recorded in the PR. Do not advertise a lane that loads the production `app` via parent conftest.
+Equivalent expanded form:
+
+```bash
+PYTHONPATH=. uv run --isolated --no-project \
+  --with 'pytest>=8.3.5' --with 'fastapi>=0.115.4' \
+  --with 'pydantic>=2.0' --with 'httpx>=0.27.0' \
+  pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+```
+
+`--confcutdir` cuts off ancestor `tests/conftest.py` (which imports production `app`).
+`--isolated --no-project` skips the project `.venv` and the root server dependency
+graph (OpenAI, Firebase, sentence-transformers, generationengine, …), installing
+only pytest/FastAPI/Pydantic/HTTPX via `--with`.
+
+The exact command must be recorded in the PR. Do not advertise `uv run pytest`
+against the project environment as the focused lane.
 
 ## 6. Acceptance criteria
 

--- a/Docs/Plans/HANDOFF-pr12-statblock-v1-bounded-context-foundation.md
+++ b/Docs/Plans/HANDOFF-pr12-statblock-v1-bounded-context-foundation.md
@@ -144,13 +144,13 @@ Required:
 - test confirms no Firebase/OpenAI provider is constructed;
 - focused test command exits successfully from a clean environment.
 
-Recommended command shape:
+Required focused command (cuts off ancestor `tests/conftest.py`):
 
 ```bash
-pytest tests/statblocks_v1/test_health.py -q
+uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
 ```
 
-The exact command must be recorded in the PR.
+The exact command must be recorded in the PR. Do not advertise a lane that loads the production `app` via parent conftest.
 
 ## 6. Acceptance criteria
 

--- a/Docs/Plans/HANDOFF-pr13-statblock-v1-contract-models-fixtures.md
+++ b/Docs/Plans/HANDOFF-pr13-statblock-v1-contract-models-fixtures.md
@@ -8,19 +8,21 @@
 
 ## Predecessor completion notes (PR12)
 
-- Package root: `statblocks_v1/` with layers `domain/`, `application/`, `infrastructure/`, `api/`.
-- Import rules (AST-enforced): domain → stdlib+Pydantic; application → domain; infrastructure → domain/application (no api); api → domain/application+FastAPI. Optional narrow exception: `routers.internal_auth` constants only. Legacy `statblockgenerator` / `StatBlockDetails` forbidden. Foundation mirrors auth header/env constants locally to avoid `routers` package side effects.
+- Package root: `statblocks_v1/` with layers `domain/`, `application/`, `infrastructure/`, `api/`. `statblocks_v1/__init__.py` is domain-safe (contract metadata only).
+- Import rules (AST-enforced): domain → stdlib+Pydantic (+ bare package root); application → domain; infrastructure → domain/application + external SDKs, **rejecting other repository-owned packages by default** (adapter exceptions opt in explicitly); api → domain/application+FastAPI. Optional narrow exception: `routers.internal_auth` constants only. Legacy `statblockgenerator` / `StatBlockDetails` forbidden. Foundation mirrors auth header/env constants locally to avoid `routers` package side effects.
 - Isolated test app factory: `statblocks_v1.testing.create_test_app()` registers typed error handlers and mounts only the v1 router — do not import production `app` in focused tests.
 - Router: `statblocks_v1.api.router.router` mounted at `/api/internal/dungeonbuddy/v1` with router-level `require_internal_service_auth`. Auth failures raise `StatblockV1HTTPError` → top-level `ErrorEnvelopeV1` (401/403/503). Misconfigured key env → **503** `internal_service_misconfigured`.
 - Health: `GET /api/internal/dungeonbuddy/v1/statblocks/health` returns foundation payload with empty `capabilities`; OpenAPI declares `HealthResponseV1` + auth error models.
 - Production registration: `register_statblocks_v1_error_handlers(app)` + `app.include_router(...)` in `app.py` (import-time coupling only; tests stay isolated).
-- Focused verification (required `--confcutdir` so `tests/conftest.py` does not preload production `app`):
+- Focused verification (import-isolated via `--confcutdir`; dependency-isolated via `uv run --isolated --no-project`):
 
 ```bash
-uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+./scripts/run_statblocks_v1_tests.sh
 ```
 
-Run with external credentials unset; a clean-process test proves `app` is never imported.
+Equivalent: `PYTHONPATH=. uv run --isolated --no-project --with 'pytest>=8.3.5' --with 'fastapi>=0.115.4' --with 'pydantic>=2.0' --with 'httpx>=0.27.0' pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q`
+
+Run with external credentials unset; clean-process tests prove `app` is never imported and heavy server deps are absent from the isolated env.
 
 ## 0. Mission
 

--- a/Docs/Plans/HANDOFF-pr13-statblock-v1-contract-models-fixtures.md
+++ b/Docs/Plans/HANDOFF-pr13-statblock-v1-contract-models-fixtures.md
@@ -9,12 +9,18 @@
 ## Predecessor completion notes (PR12)
 
 - Package root: `statblocks_v1/` with layers `domain/`, `application/`, `infrastructure/`, `api/`.
-- Import rules: domain is stdlib+Pydantic only; api may use FastAPI + `routers.internal_auth`; legacy `statblockgenerator` is forbidden in domain/api sources.
-- Isolated test app factory: `statblocks_v1.testing.create_test_app()` — do not import production `app` in focused tests.
-- Router: `statblocks_v1.api.router.router` mounted at `/api/internal/dungeonbuddy/v1` with router-level `require_internal_service_auth`.
-- Health: `GET /api/internal/dungeonbuddy/v1/statblocks/health` returns foundation payload with empty `capabilities`.
-- Production registration: narrow `app.include_router(dungeonbuddy_statblocks_v1_router)` in `app.py` (import-time coupling only; tests stay isolated).
-- Focused verification: `uv run pytest tests/statblocks_v1/ -q`
+- Import rules (AST-enforced): domain → stdlib+Pydantic; application → domain; infrastructure → domain/application (no api); api → domain/application+FastAPI. Optional narrow exception: `routers.internal_auth` constants only. Legacy `statblockgenerator` / `StatBlockDetails` forbidden. Foundation mirrors auth header/env constants locally to avoid `routers` package side effects.
+- Isolated test app factory: `statblocks_v1.testing.create_test_app()` registers typed error handlers and mounts only the v1 router — do not import production `app` in focused tests.
+- Router: `statblocks_v1.api.router.router` mounted at `/api/internal/dungeonbuddy/v1` with router-level `require_internal_service_auth`. Auth failures raise `StatblockV1HTTPError` → top-level `ErrorEnvelopeV1` (401/403/503). Misconfigured key env → **503** `internal_service_misconfigured`.
+- Health: `GET /api/internal/dungeonbuddy/v1/statblocks/health` returns foundation payload with empty `capabilities`; OpenAPI declares `HealthResponseV1` + auth error models.
+- Production registration: `register_statblocks_v1_error_handlers(app)` + `app.include_router(...)` in `app.py` (import-time coupling only; tests stay isolated).
+- Focused verification (required `--confcutdir` so `tests/conftest.py` does not preload production `app`):
+
+```bash
+uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+```
+
+Run with external credentials unset; a clean-process test proves `app` is never imported.
 
 ## 0. Mission
 

--- a/Docs/Plans/HANDOFF-pr13-statblock-v1-contract-models-fixtures.md
+++ b/Docs/Plans/HANDOFF-pr13-statblock-v1-contract-models-fixtures.md
@@ -6,6 +6,16 @@
 **Successor:** `HANDOFF-pr14-statblock-v1-canonicalization-validation-digest.md`  
 **Authority:** `Docs/Design/DESIGN-dungeonbuddy-statblock-contract-v1.md`
 
+## Predecessor completion notes (PR12)
+
+- Package root: `statblocks_v1/` with layers `domain/`, `application/`, `infrastructure/`, `api/`.
+- Import rules: domain is stdlib+Pydantic only; api may use FastAPI + `routers.internal_auth`; legacy `statblockgenerator` is forbidden in domain/api sources.
+- Isolated test app factory: `statblocks_v1.testing.create_test_app()` — do not import production `app` in focused tests.
+- Router: `statblocks_v1.api.router.router` mounted at `/api/internal/dungeonbuddy/v1` with router-level `require_internal_service_auth`.
+- Health: `GET /api/internal/dungeonbuddy/v1/statblocks/health` returns foundation payload with empty `capabilities`.
+- Production registration: narrow `app.include_router(dungeonbuddy_statblocks_v1_router)` in `app.py` (import-time coupling only; tests stay isolated).
+- Focused verification: `uv run pytest tests/statblocks_v1/ -q`
+
 ## 0. Mission
 
 Translate the approved contract design into executable Pydantic models and representative fixtures without adding provider, persistence, or production write behavior.

--- a/app.py
+++ b/app.py
@@ -54,6 +54,9 @@ from routers.cardgenerator_compatibility_router import router as cardgenerator_c
 # Import StatBlockGenerator router
 from routers.statblockgenerator_router import router as statblockgenerator_router
 
+# Import DungeonBuddy statblock v1 bounded-context router
+from statblocks_v1.api.router import router as dungeonbuddy_statblocks_v1_router
+
 # Import PlayerCharacterGenerator router
 from routers.playercharactergenerator_router import router as playercharactergenerator_router
 
@@ -208,6 +211,12 @@ app.include_router(
 app.include_router(
     statblockgenerator_router,
     tags=["StatBlock Generator"]
+)
+
+# Include DungeonBuddy statblock v1 router (foundation health only in PR12)
+app.include_router(
+    dungeonbuddy_statblocks_v1_router,
+    tags=["DungeonBuddy Statblocks v1"]
 )
 
 # Include PlayerCharacterGenerator router

--- a/app.py
+++ b/app.py
@@ -55,6 +55,7 @@ from routers.cardgenerator_compatibility_router import router as cardgenerator_c
 from routers.statblockgenerator_router import router as statblockgenerator_router
 
 # Import DungeonBuddy statblock v1 bounded-context router
+from statblocks_v1.api.http_errors import register_error_handlers as register_statblocks_v1_error_handlers
 from statblocks_v1.api.router import router as dungeonbuddy_statblocks_v1_router
 
 # Import PlayerCharacterGenerator router
@@ -214,6 +215,7 @@ app.include_router(
 )
 
 # Include DungeonBuddy statblock v1 router (foundation health only in PR12)
+register_statblocks_v1_error_handlers(app)
 app.include_router(
     dungeonbuddy_statblocks_v1_router,
     tags=["DungeonBuddy Statblocks v1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,12 @@ packages = [
     "cloudflareR2",
     "cardgenerator",
     "storegenerator",
-    "playercharactergenerator"
+    "playercharactergenerator",
+    "statblocks_v1",
+    "statblocks_v1.domain",
+    "statblocks_v1.application",
+    "statblocks_v1.infrastructure",
+    "statblocks_v1.api",
 ]
 
 [tool.uv.sources]

--- a/scripts/run_statblocks_v1_tests.sh
+++ b/scripts/run_statblocks_v1_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Project-independent focused lane for statblocks_v1.
+#
+# Uses an ephemeral env (``--isolated --no-project``) so the project ``.venv``
+# and full server graph (OpenAI, Firebase, Firestore, Fal, sentence-transformers,
+# generationengine) are never required.
+#
+# Usage (from repository root):
+#   ./scripts/run_statblocks_v1_tests.sh
+#   ./scripts/run_statblocks_v1_tests.sh -k health
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export PYTHONPATH="${ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec uv run --isolated --no-project \
+  --with 'pytest>=8.3.5' \
+  --with 'fastapi>=0.115.4' \
+  --with 'pydantic>=2.0' \
+  --with 'httpx>=0.27.0' \
+  pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q "$@"

--- a/statblocks_v1/__init__.py
+++ b/statblocks_v1/__init__.py
@@ -1,0 +1,15 @@
+"""DungeonBuddy statblock contract v1 bounded context.
+
+Import rules (enforced by package layout and focused tests):
+
+- ``domain`` may depend on the standard library and Pydantic only.
+- ``application`` may depend on ``domain``.
+- ``infrastructure`` may depend on ``domain`` / ``application`` plus external SDKs.
+- ``api`` may depend on ``domain`` / ``application`` and FastAPI.
+- Legacy generator packages must not be imported into ``domain``.
+"""
+
+CONTRACT_NAME = "dungeonmind.dungeonbuddy-statblocks"
+CONTRACT_VERSION = "1.0.0"
+
+__all__ = ["CONTRACT_NAME", "CONTRACT_VERSION"]

--- a/statblocks_v1/api/__init__.py
+++ b/statblocks_v1/api/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP surface for the DungeonBuddy statblock v1 contract."""
+
+from statblocks_v1.api.router import router
+
+__all__ = ["router"]

--- a/statblocks_v1/api/dependencies.py
+++ b/statblocks_v1/api/dependencies.py
@@ -2,33 +2,29 @@
 
 Authentication reuses the shared DungeonBuddy internal-key comparison while
 mapping failures into the preliminary typed v1 error envelope.
+
+Constant names mirror ``routers.internal_auth`` so header/env contracts stay
+aligned, without importing the ``routers`` package (its ``__init__`` loads
+unrelated OAuth routers and credentials).
 """
 
 from __future__ import annotations
 
 import os
 import secrets
-from typing import Annotated, Any
+from typing import Annotated
 
-from fastapi import Header, HTTPException
+from fastapi import Header
 
-from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
+from statblocks_v1.api.http_errors import StatblockV1HTTPError
 from statblocks_v1.domain.errors import (
     InternalServiceMisconfiguredError,
     UnauthorizedInternalClientError,
 )
 
-
-def _error_body(error: UnauthorizedInternalClientError | InternalServiceMisconfiguredError) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "error": {
-            "code": error.code,
-            "message": error.message,
-        }
-    }
-    if error.details:
-        body["error"]["details"] = error.details
-    return body
+# Keep identical to routers.internal_auth (shared wire contract).
+INTERNAL_KEY_HEADER = "X-DungeonBuddy-Internal-Key"
+INTERNAL_KEY_ENV = "DUNGEONBUDDY_INTERNAL_API_KEY"
 
 
 async def require_internal_service_auth(
@@ -40,19 +36,16 @@ async def require_internal_service_auth(
     """Require the DungeonBuddy internal API key for all v1 routes."""
     expected_key = os.getenv(INTERNAL_KEY_ENV)
     if not expected_key:
-        raise HTTPException(
-            status_code=500,
-            detail=_error_body(InternalServiceMisconfiguredError()),
-        )
+        raise StatblockV1HTTPError(503, InternalServiceMisconfiguredError())
 
     if x_dungeonbuddy_internal_key is None:
-        raise HTTPException(
-            status_code=401,
-            detail=_error_body(UnauthorizedInternalClientError("Missing internal API key")),
+        raise StatblockV1HTTPError(
+            401,
+            UnauthorizedInternalClientError("Missing internal API key"),
         )
 
     if not secrets.compare_digest(x_dungeonbuddy_internal_key, expected_key):
-        raise HTTPException(
-            status_code=403,
-            detail=_error_body(UnauthorizedInternalClientError("Invalid internal API key")),
+        raise StatblockV1HTTPError(
+            403,
+            UnauthorizedInternalClientError("Invalid internal API key"),
         )

--- a/statblocks_v1/api/dependencies.py
+++ b/statblocks_v1/api/dependencies.py
@@ -1,0 +1,58 @@
+"""FastAPI dependencies for the v1 router.
+
+Authentication reuses the shared DungeonBuddy internal-key comparison while
+mapping failures into the preliminary typed v1 error envelope.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Annotated, Any
+
+from fastapi import Header, HTTPException
+
+from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
+from statblocks_v1.domain.errors import (
+    InternalServiceMisconfiguredError,
+    UnauthorizedInternalClientError,
+)
+
+
+def _error_body(error: UnauthorizedInternalClientError | InternalServiceMisconfiguredError) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "error": {
+            "code": error.code,
+            "message": error.message,
+        }
+    }
+    if error.details:
+        body["error"]["details"] = error.details
+    return body
+
+
+async def require_internal_service_auth(
+    x_dungeonbuddy_internal_key: Annotated[
+        str | None,
+        Header(alias=INTERNAL_KEY_HEADER),
+    ] = None,
+) -> None:
+    """Require the DungeonBuddy internal API key for all v1 routes."""
+    expected_key = os.getenv(INTERNAL_KEY_ENV)
+    if not expected_key:
+        raise HTTPException(
+            status_code=500,
+            detail=_error_body(InternalServiceMisconfiguredError()),
+        )
+
+    if x_dungeonbuddy_internal_key is None:
+        raise HTTPException(
+            status_code=401,
+            detail=_error_body(UnauthorizedInternalClientError("Missing internal API key")),
+        )
+
+    if not secrets.compare_digest(x_dungeonbuddy_internal_key, expected_key):
+        raise HTTPException(
+            status_code=403,
+            detail=_error_body(UnauthorizedInternalClientError("Invalid internal API key")),
+        )

--- a/statblocks_v1/api/http_errors.py
+++ b/statblocks_v1/api/http_errors.py
@@ -1,0 +1,52 @@
+"""Typed HTTP error transport for the v1 router.
+
+Auth and other foundation failures raise ``StatblockV1HTTPError``. An app-level
+exception handler converts those into a top-level ``ErrorEnvelopeV1`` JSON body
+so FastAPI never wraps the envelope under ``{"detail": ...}``.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from statblocks_v1.api.models import ErrorDetailV1, ErrorEnvelopeV1
+from statblocks_v1.domain.errors import StatblockV1Error
+
+
+class StatblockV1HTTPError(Exception):
+    """Domain error paired with the HTTP status code to emit."""
+
+    def __init__(self, status_code: int, error: StatblockV1Error) -> None:
+        self.status_code = status_code
+        self.error = error
+        super().__init__(f"{status_code} {error.code}: {error.message}")
+
+
+def envelope_for(error: StatblockV1Error) -> dict[str, object]:
+    return ErrorEnvelopeV1(
+        error=ErrorDetailV1(
+            code=error.code,
+            message=error.message,
+            details=error.details,
+        )
+    ).model_dump(mode="json", exclude_none=True)
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """Install handlers that emit the top-level v1 error envelope."""
+
+    @app.exception_handler(StatblockV1HTTPError)
+    async def handle_statblock_v1_http_error(
+        _request: Request,
+        exc: StatblockV1HTTPError,
+    ) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content=envelope_for(exc.error))
+
+    @app.exception_handler(StatblockV1Error)
+    async def handle_statblock_v1_error(
+        _request: Request,
+        exc: StatblockV1Error,
+    ) -> JSONResponse:
+        # Bare domain errors default to 500; auth uses StatblockV1HTTPError for status.
+        return JSONResponse(status_code=500, content=envelope_for(exc))

--- a/statblocks_v1/api/models.py
+++ b/statblocks_v1/api/models.py
@@ -1,0 +1,32 @@
+"""Preliminary HTTP DTOs for the DungeonBuddy statblock v1 contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StrictModel(BaseModel):
+    """Shared base for v1 transport models (extra fields forbidden)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ErrorDetailV1(StrictModel):
+    code: str
+    message: str
+    details: dict[str, Any] | None = None
+
+
+class ErrorEnvelopeV1(StrictModel):
+    """Top-level typed error body returned by v1 routes (never nested under ``detail``)."""
+
+    error: ErrorDetailV1
+
+
+class HealthResponseV1(StrictModel):
+    status: str
+    contract: str
+    contract_version: str
+    capabilities: list[str] = Field(default_factory=list)

--- a/statblocks_v1/api/router.py
+++ b/statblocks_v1/api/router.py
@@ -1,0 +1,25 @@
+"""DungeonBuddy-facing internal router for statblock contract v1."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from statblocks_v1 import CONTRACT_NAME, CONTRACT_VERSION
+from statblocks_v1.api.dependencies import require_internal_service_auth
+
+router = APIRouter(
+    prefix="/api/internal/dungeonbuddy/v1",
+    tags=["DungeonBuddy Statblocks v1"],
+    dependencies=[Depends(require_internal_service_auth)],
+)
+
+
+@router.get("/statblocks/health")
+async def health() -> dict[str, object]:
+    """Foundation capability discovery. No generation or persistence yet."""
+    return {
+        "status": "foundation",
+        "contract": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "capabilities": [],
+    }

--- a/statblocks_v1/api/router.py
+++ b/statblocks_v1/api/router.py
@@ -6,20 +6,35 @@ from fastapi import APIRouter, Depends
 
 from statblocks_v1 import CONTRACT_NAME, CONTRACT_VERSION
 from statblocks_v1.api.dependencies import require_internal_service_auth
+from statblocks_v1.api.models import ErrorEnvelopeV1, HealthResponseV1
+
+_AUTH_ERROR_RESPONSES = {
+    401: {"model": ErrorEnvelopeV1, "description": "Missing internal API key"},
+    403: {"model": ErrorEnvelopeV1, "description": "Invalid internal API key"},
+    503: {
+        "model": ErrorEnvelopeV1,
+        "description": "Internal service misconfigured (missing API key env)",
+    },
+}
 
 router = APIRouter(
     prefix="/api/internal/dungeonbuddy/v1",
     tags=["DungeonBuddy Statblocks v1"],
     dependencies=[Depends(require_internal_service_auth)],
+    responses=_AUTH_ERROR_RESPONSES,
 )
 
 
-@router.get("/statblocks/health")
-async def health() -> dict[str, object]:
+@router.get(
+    "/statblocks/health",
+    response_model=HealthResponseV1,
+    responses=_AUTH_ERROR_RESPONSES,
+)
+async def health() -> HealthResponseV1:
     """Foundation capability discovery. No generation or persistence yet."""
-    return {
-        "status": "foundation",
-        "contract": CONTRACT_NAME,
-        "contract_version": CONTRACT_VERSION,
-        "capabilities": [],
-    }
+    return HealthResponseV1(
+        status="foundation",
+        contract=CONTRACT_NAME,
+        contract_version=CONTRACT_VERSION,
+        capabilities=[],
+    )

--- a/statblocks_v1/application/__init__.py
+++ b/statblocks_v1/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application services for statblock v1 (use cases land in later PRs)."""

--- a/statblocks_v1/domain/__init__.py
+++ b/statblocks_v1/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure domain layer for statblock v1."""

--- a/statblocks_v1/domain/errors.py
+++ b/statblocks_v1/domain/errors.py
@@ -1,0 +1,34 @@
+"""Typed domain/application errors for the statblock v1 contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class StatblockV1Error(Exception):
+    """Base error with a stable machine-readable code."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.code = code
+        self.message = message
+        self.details = details
+        super().__init__(f"{code}: {message}")
+
+
+class UnauthorizedInternalClientError(StatblockV1Error):
+    """Caller failed internal service authentication."""
+
+    def __init__(self, message: str = "Unauthorized internal client") -> None:
+        super().__init__(code="unauthorized_internal_client", message=message)
+
+
+class InternalServiceMisconfiguredError(StatblockV1Error):
+    """Server-side configuration required for the route is missing."""
+
+    def __init__(self, message: str = "Internal service is misconfigured") -> None:
+        super().__init__(code="internal_service_misconfigured", message=message)

--- a/statblocks_v1/domain/protocols.py
+++ b/statblocks_v1/domain/protocols.py
@@ -1,0 +1,47 @@
+"""Narrow dependency seams for later PRs.
+
+These protocols intentionally declare only the capability shape. Concrete
+infrastructure adapters and repository methods land in later stacked PRs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    def now(self) -> datetime:
+        """Return the current UTC timestamp used for server envelopes."""
+
+
+@runtime_checkable
+class IdAllocator(Protocol):
+    def allocate(self, prefix: str) -> str:
+        """Allocate a server-owned opaque identifier with the given prefix."""
+
+
+@runtime_checkable
+class GenerationProvider(Protocol):
+    """Structured Outputs provider seam (implemented in PR16)."""
+
+
+@runtime_checkable
+class CandidateRepository(Protocol):
+    """Candidate persistence seam (implemented in PR15)."""
+
+
+@runtime_checkable
+class StatblockRepository(Protocol):
+    """Logical statblock persistence seam (implemented in PR15)."""
+
+
+@runtime_checkable
+class RevisionRepository(Protocol):
+    """Immutable revision persistence seam (implemented in PR15)."""
+
+
+@runtime_checkable
+class AssetGateway(Protocol):
+    """Asset reference gateway seam (implemented in PR19)."""

--- a/statblocks_v1/domain/protocols.py
+++ b/statblocks_v1/domain/protocols.py
@@ -2,6 +2,9 @@
 
 These protocols intentionally declare only the capability shape. Concrete
 infrastructure adapters and repository methods land in later stacked PRs.
+
+Empty placeholder protocols are not ``@runtime_checkable``: an empty structural
+protocol is satisfied by any object, which makes ``isinstance`` checks misleading.
 """
 
 from __future__ import annotations
@@ -22,26 +25,21 @@ class IdAllocator(Protocol):
         """Allocate a server-owned opaque identifier with the given prefix."""
 
 
-@runtime_checkable
 class GenerationProvider(Protocol):
     """Structured Outputs provider seam (implemented in PR16)."""
 
 
-@runtime_checkable
 class CandidateRepository(Protocol):
     """Candidate persistence seam (implemented in PR15)."""
 
 
-@runtime_checkable
 class StatblockRepository(Protocol):
     """Logical statblock persistence seam (implemented in PR15)."""
 
 
-@runtime_checkable
 class RevisionRepository(Protocol):
     """Immutable revision persistence seam (implemented in PR15)."""
 
 
-@runtime_checkable
 class AssetGateway(Protocol):
     """Asset reference gateway seam (implemented in PR19)."""

--- a/statblocks_v1/infrastructure/__init__.py
+++ b/statblocks_v1/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapters for statblock v1 (concrete SDKs land in later PRs)."""

--- a/statblocks_v1/testing.py
+++ b/statblocks_v1/testing.py
@@ -3,9 +3,18 @@
 Tests must import from this module (or construct an equivalent app) rather than
 importing the production ``app`` module.
 
-Focused lane (does not load ``tests/conftest.py``, which imports production ``app``):
+Focused lane (import-isolated via ``--confcutdir`` and dependency-isolated via
+``uv run --isolated --no-project`` — does not use ``.venv`` or sync the full
+server environment):
 
-    uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+    ./scripts/run_statblocks_v1_tests.sh
+
+Equivalent:
+
+    PYTHONPATH=. uv run --isolated --no-project \\
+      --with 'pytest>=8.3.5' --with 'fastapi>=0.115.4' \\
+      --with 'pydantic>=2.0' --with 'httpx>=0.27.0' \\
+      pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
 """
 
 from __future__ import annotations

--- a/statblocks_v1/testing.py
+++ b/statblocks_v1/testing.py
@@ -2,17 +2,23 @@
 
 Tests must import from this module (or construct an equivalent app) rather than
 importing the production ``app`` module.
+
+Focused lane (does not load ``tests/conftest.py``, which imports production ``app``):
+
+    uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
 """
 
 from __future__ import annotations
 
 from fastapi import FastAPI
 
+from statblocks_v1.api.http_errors import register_error_handlers
 from statblocks_v1.api.router import router
 
 
 def create_test_app() -> FastAPI:
     """Return a FastAPI app that mounts only the statblock v1 router."""
     app = FastAPI(title="statblocks_v1-test")
+    register_error_handlers(app)
     app.include_router(router)
     return app

--- a/statblocks_v1/testing.py
+++ b/statblocks_v1/testing.py
@@ -1,0 +1,18 @@
+"""Isolated FastAPI app factory for focused v1 tests.
+
+Tests must import from this module (or construct an equivalent app) rather than
+importing the production ``app`` module.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from statblocks_v1.api.router import router
+
+
+def create_test_app() -> FastAPI:
+    """Return a FastAPI app that mounts only the statblock v1 router."""
+    app = FastAPI(title="statblocks_v1-test")
+    app.include_router(router)
+    return app

--- a/tests/statblocks_v1/conftest.py
+++ b/tests/statblocks_v1/conftest.py
@@ -2,12 +2,21 @@
 
 These tests intentionally do not import the production ``app`` module.
 
-Run with::
+Run with the project-independent lane (no full-server dependency sync)::
 
-    uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+    ./scripts/run_statblocks_v1_tests.sh
+
+Or::
+
+    PYTHONPATH=. uv run --isolated --no-project \\
+      --with 'pytest>=8.3.5' --with 'fastapi>=0.115.4' \\
+      --with 'pydantic>=2.0' --with 'httpx>=0.27.0' \\
+      pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
 
 ``--confcutdir`` prevents loading ``tests/conftest.py``, which imports the
-full production app at collection time.
+full production app at collection time. ``--isolated --no-project`` prevents
+``uv`` from using the project ``.venv`` or synchronizing OpenAI, Firebase,
+sentence-transformers, generationengine, etc.
 """
 
 from __future__ import annotations

--- a/tests/statblocks_v1/conftest.py
+++ b/tests/statblocks_v1/conftest.py
@@ -1,0 +1,31 @@
+"""Focused fixtures for the statblocks_v1 bounded context.
+
+These tests intentionally do not import the production ``app`` module.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
+from statblocks_v1.testing import create_test_app
+
+TEST_INTERNAL_KEY = "test-statblocks-v1-internal-key"
+
+
+@pytest.fixture
+def auth_headers() -> dict[str, str]:
+    return {INTERNAL_KEY_HEADER: TEST_INTERNAL_KEY}
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+    return TestClient(create_test_app())
+
+
+@pytest.fixture
+def unconfigured_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.delenv(INTERNAL_KEY_ENV, raising=False)
+    return TestClient(create_test_app())

--- a/tests/statblocks_v1/conftest.py
+++ b/tests/statblocks_v1/conftest.py
@@ -1,6 +1,13 @@
 """Focused fixtures for the statblocks_v1 bounded context.
 
 These tests intentionally do not import the production ``app`` module.
+
+Run with::
+
+    uv run pytest --confcutdir=tests/statblocks_v1 tests/statblocks_v1 -q
+
+``--confcutdir`` prevents loading ``tests/conftest.py``, which imports the
+full production app at collection time.
 """
 
 from __future__ import annotations
@@ -8,7 +15,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
+from statblocks_v1.api.dependencies import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
 from statblocks_v1.testing import create_test_app
 
 TEST_INTERNAL_KEY = "test-statblocks-v1-internal-key"

--- a/tests/statblocks_v1/test_health.py
+++ b/tests/statblocks_v1/test_health.py
@@ -4,18 +4,21 @@ from __future__ import annotations
 
 import ast
 import importlib
+import os
+import subprocess
 import sys
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
 from statblocks_v1 import CONTRACT_NAME, CONTRACT_VERSION
+from statblocks_v1.api.dependencies import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
 from statblocks_v1.testing import create_test_app
 
 HEALTH_PATH = "/api/internal/dungeonbuddy/v1/statblocks/health"
 TEST_INTERNAL_KEY = "test-statblocks-v1-internal-key"
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "statblocks_v1"
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_domain_package_imports_without_external_env(monkeypatch) -> None:
@@ -50,9 +53,10 @@ def test_health_missing_header_denied(client: TestClient) -> None:
     response = client.get(HEALTH_PATH)
 
     assert response.status_code == 401
-    body = response.json()["detail"]["error"]
-    assert body["code"] == "unauthorized_internal_client"
-    assert "Missing" in body["message"]
+    body = response.json()
+    assert set(body.keys()) == {"error"}
+    assert body["error"]["code"] == "unauthorized_internal_client"
+    assert "Missing" in body["error"]["message"]
 
 
 def test_health_wrong_header_denied(client: TestClient) -> None:
@@ -62,9 +66,10 @@ def test_health_wrong_header_denied(client: TestClient) -> None:
     )
 
     assert response.status_code == 403
-    body = response.json()["detail"]["error"]
-    assert body["code"] == "unauthorized_internal_client"
-    assert "Invalid" in body["message"]
+    body = response.json()
+    assert set(body.keys()) == {"error"}
+    assert body["error"]["code"] == "unauthorized_internal_client"
+    assert "Invalid" in body["error"]["message"]
 
 
 def test_health_missing_server_env_fails_closed(unconfigured_client: TestClient) -> None:
@@ -73,9 +78,10 @@ def test_health_missing_server_env_fails_closed(unconfigured_client: TestClient)
         headers={INTERNAL_KEY_HEADER: TEST_INTERNAL_KEY},
     )
 
-    assert response.status_code == 500
-    body = response.json()["detail"]["error"]
-    assert body["code"] == "internal_service_misconfigured"
+    assert response.status_code == 503
+    body = response.json()
+    assert set(body.keys()) == {"error"}
+    assert body["error"]["code"] == "internal_service_misconfigured"
 
 
 def test_create_test_app_does_not_import_production_app() -> None:
@@ -83,6 +89,105 @@ def test_create_test_app_does_not_import_production_app() -> None:
     create_test_app()
     newly_loaded = set(sys.modules) - before
     assert "app" not in newly_loaded
+
+
+def test_clean_process_never_imports_production_app() -> None:
+    """Prove isolation in a fresh interpreter (parent conftest cannot preload ``app``)."""
+    script = """
+import os
+import sys
+
+for key in (
+    "DUNGEONBUDDY_INTERNAL_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "FIREBASE_CREDENTIALS",
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+):
+    os.environ.pop(key, None)
+
+assert "app" not in sys.modules
+
+from fastapi.testclient import TestClient
+from statblocks_v1.testing import create_test_app
+
+assert "app" not in sys.modules
+app = create_test_app()
+assert "app" not in sys.modules
+
+os.environ["DUNGEONBUDDY_INTERNAL_API_KEY"] = "isolation-key"
+client = TestClient(app)
+response = client.get(
+    "/api/internal/dungeonbuddy/v1/statblocks/health",
+    headers={"X-DungeonBuddy-Internal-Key": "isolation-key"},
+)
+assert response.status_code == 200, response.text
+assert "app" not in sys.modules
+print("ok")
+"""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key
+        not in {
+            "DUNGEONBUDDY_INTERNAL_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "FIREBASE_CREDENTIALS",
+            "GOOGLE_CLIENT_ID",
+            "GOOGLE_CLIENT_SECRET",
+        }
+    }
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "ok" in completed.stdout
+
+
+def test_focused_lane_skips_parent_conftest() -> None:
+    """Advertised lane must not load ``tests/conftest.py`` (imports production ``app``)."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key
+        not in {
+            "DUNGEONBUDDY_INTERNAL_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "FIREBASE_CREDENTIALS",
+            "GOOGLE_CLIENT_ID",
+            "GOOGLE_CLIENT_SECRET",
+        }
+    }
+    completed = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "--confcutdir=tests/statblocks_v1",
+            "--trace-config",
+            "tests/statblocks_v1/test_import_boundaries.py",
+            "--collect-only",
+            "-q",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == 0, output
+    assert "tests/conftest.py" not in output
+    assert "tests/statblocks_v1/conftest.py" in output
 
 
 def test_package_source_does_not_construct_firebase_or_openai() -> None:
@@ -95,7 +200,6 @@ def test_package_source_does_not_construct_firebase_or_openai() -> None:
         "statblockgenerator",
     )
     for path in PACKAGE_ROOT.rglob("*.py"):
-        # api/dependencies may import routers.internal_auth only.
         source = path.read_text()
         tree = ast.parse(source)
         for node in ast.walk(tree):
@@ -105,3 +209,15 @@ def test_package_source_does_not_construct_firebase_or_openai() -> None:
                 assert node.func.attr != "OpenAI", f"{path} constructs OpenAI"
         for token in forbidden_tokens:
             assert token not in source, f"{path} contains forbidden token {token!r}"
+
+
+def test_openapi_declares_typed_auth_error_responses(client: TestClient) -> None:
+    schema = client.app.openapi()
+    health = schema["paths"][HEALTH_PATH]["get"]
+    assert "401" in health["responses"]
+    assert "403" in health["responses"]
+    assert "503" in health["responses"]
+    components = schema["components"]["schemas"]
+    assert "ErrorEnvelopeV1" in components
+    assert "ErrorDetailV1" in components
+    assert "HealthResponseV1" in components

--- a/tests/statblocks_v1/test_health.py
+++ b/tests/statblocks_v1/test_health.py
@@ -1,0 +1,107 @@
+"""Foundation health and auth coverage for statblocks_v1."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
+from statblocks_v1 import CONTRACT_NAME, CONTRACT_VERSION
+from statblocks_v1.testing import create_test_app
+
+HEALTH_PATH = "/api/internal/dungeonbuddy/v1/statblocks/health"
+TEST_INTERNAL_KEY = "test-statblocks-v1-internal-key"
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "statblocks_v1"
+
+
+def test_domain_package_imports_without_external_env(monkeypatch) -> None:
+    monkeypatch.delenv(INTERNAL_KEY_ENV, raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    for name in list(sys.modules):
+        if name == "statblocks_v1" or name.startswith("statblocks_v1."):
+            del sys.modules[name]
+
+    domain_errors = importlib.import_module("statblocks_v1.domain.errors")
+    domain_protocols = importlib.import_module("statblocks_v1.domain.protocols")
+
+    assert domain_errors.UnauthorizedInternalClientError().code == "unauthorized_internal_client"
+    assert domain_protocols.Clock is not None
+
+
+def test_health_returns_foundation_contract(client: TestClient, auth_headers: dict[str, str]) -> None:
+    response = client.get(HEALTH_PATH, headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "foundation",
+        "contract": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "capabilities": [],
+    }
+
+
+def test_health_missing_header_denied(client: TestClient) -> None:
+    response = client.get(HEALTH_PATH)
+
+    assert response.status_code == 401
+    body = response.json()["detail"]["error"]
+    assert body["code"] == "unauthorized_internal_client"
+    assert "Missing" in body["message"]
+
+
+def test_health_wrong_header_denied(client: TestClient) -> None:
+    response = client.get(
+        HEALTH_PATH,
+        headers={INTERNAL_KEY_HEADER: "wrong-key"},
+    )
+
+    assert response.status_code == 403
+    body = response.json()["detail"]["error"]
+    assert body["code"] == "unauthorized_internal_client"
+    assert "Invalid" in body["message"]
+
+
+def test_health_missing_server_env_fails_closed(unconfigured_client: TestClient) -> None:
+    response = unconfigured_client.get(
+        HEALTH_PATH,
+        headers={INTERNAL_KEY_HEADER: TEST_INTERNAL_KEY},
+    )
+
+    assert response.status_code == 500
+    body = response.json()["detail"]["error"]
+    assert body["code"] == "internal_service_misconfigured"
+
+
+def test_create_test_app_does_not_import_production_app() -> None:
+    before = set(sys.modules)
+    create_test_app()
+    newly_loaded = set(sys.modules) - before
+    assert "app" not in newly_loaded
+
+
+def test_package_source_does_not_construct_firebase_or_openai() -> None:
+    """Static guard: foundation code never constructs Firebase/OpenAI clients."""
+    forbidden_tokens = (
+        "OpenAI(",
+        "firebase_admin",
+        "firestore.firebase_config",
+        "StatBlockDetails",
+        "statblockgenerator",
+    )
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        # api/dependencies may import routers.internal_auth only.
+        source = path.read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id != "OpenAI", f"{path} constructs OpenAI"
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                assert node.func.attr != "OpenAI", f"{path} constructs OpenAI"
+        for token in forbidden_tokens:
+            assert token not in source, f"{path} contains forbidden token {token!r}"

--- a/tests/statblocks_v1/test_health.py
+++ b/tests/statblocks_v1/test_health.py
@@ -19,6 +19,55 @@ HEALTH_PATH = "/api/internal/dungeonbuddy/v1/statblocks/health"
 TEST_INTERNAL_KEY = "test-statblocks-v1-internal-key"
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "statblocks_v1"
 REPO_ROOT = Path(__file__).resolve().parents[2]
+MINIMAL_UV_WITH = (
+    "--with",
+    "pytest>=8.3.5",
+    "--with",
+    "fastapi>=0.115.4",
+    "--with",
+    "pydantic>=2.0",
+    "--with",
+    "httpx>=0.27.0",
+)
+HEAVY_DEPENDENCY_MODULES = (
+    "openai",
+    "firebase_admin",
+    "google",
+    "fal_client",
+    "sentence_transformers",
+    "generationengine",
+)
+
+
+def _credential_scrubbed_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key
+        not in {
+            "DUNGEONBUDDY_INTERNAL_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "FIREBASE_CREDENTIALS",
+            "GOOGLE_CLIENT_ID",
+            "GOOGLE_CLIENT_SECRET",
+        }
+    }
+
+
+def _minimal_uv_run_prefix() -> list[str]:
+    """Project-independent uv invocation (ephemeral env, no root dependency sync)."""
+    return [
+        "uv",
+        "run",
+        "--isolated",
+        "--no-project",
+        *MINIMAL_UV_WITH,
+    ]
+
+
+def _minimal_uv_pytest_prefix() -> list[str]:
+    return [*_minimal_uv_run_prefix(), "pytest", "--confcutdir=tests/statblocks_v1"]
 
 
 def test_domain_package_imports_without_external_env(monkeypatch) -> None:
@@ -154,25 +203,11 @@ print("ok")
 
 def test_focused_lane_skips_parent_conftest() -> None:
     """Advertised lane must not load ``tests/conftest.py`` (imports production ``app``)."""
-    env = {
-        key: value
-        for key, value in os.environ.items()
-        if key
-        not in {
-            "DUNGEONBUDDY_INTERNAL_API_KEY",
-            "OPENAI_API_KEY",
-            "GOOGLE_APPLICATION_CREDENTIALS",
-            "FIREBASE_CREDENTIALS",
-            "GOOGLE_CLIENT_ID",
-            "GOOGLE_CLIENT_SECRET",
-        }
-    }
+    env = _credential_scrubbed_env()
+    env["PYTHONPATH"] = str(REPO_ROOT)
     completed = subprocess.run(
         [
-            "uv",
-            "run",
-            "pytest",
-            "--confcutdir=tests/statblocks_v1",
+            *_minimal_uv_pytest_prefix(),
             "--trace-config",
             "tests/statblocks_v1/test_import_boundaries.py",
             "--collect-only",
@@ -188,6 +223,34 @@ def test_focused_lane_skips_parent_conftest() -> None:
     assert completed.returncode == 0, output
     assert "tests/conftest.py" not in output
     assert "tests/statblocks_v1/conftest.py" in output
+
+
+def test_minimal_lane_excludes_full_server_dependencies() -> None:
+    """``uv run --isolated --no-project`` must not install the production dependency graph."""
+    probe = (
+        "import importlib.util as u\n"
+        + "\n".join(
+            f"assert u.find_spec({module!r}) is None, {module!r}"
+            for module in HEAVY_DEPENDENCY_MODULES
+        )
+        + "\nprint('ok')\n"
+    )
+    env = _credential_scrubbed_env()
+    completed = subprocess.run(
+        [
+            *_minimal_uv_run_prefix(),
+            "python",
+            "-c",
+            probe,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "ok" in completed.stdout
 
 
 def test_package_source_does_not_construct_firebase_or_openai() -> None:

--- a/tests/statblocks_v1/test_import_boundaries.py
+++ b/tests/statblocks_v1/test_import_boundaries.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_ROOT = REPO_ROOT / "statblocks_v1"
 
@@ -169,22 +171,52 @@ def test_domain_imports_only_stdlib_and_pydantic() -> None:
         _assert_domain_safe_imports(path)
 
 
-def test_application_depends_only_on_domain() -> None:
+def _assert_application_import(name: str, *, path: Path | str = "<synthetic>") -> None:
+    """Enforce application → domain (stdlib/Pydantic allowed; outer layers rejected)."""
     allowed_roots = STDLIB_AND_TYPING_ROOTS | {"pydantic", "statblocks_v1"}
+    root = name.split(".")[0]
+    assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
+    assert root not in REPO_OWNED_PACKAGE_ROOTS, (
+        f"application must not import repository package {root!r} ({path})"
+    )
+    if name == "statblocks_v1":
+        return
+    layer = _layer_of(name)
+    if layer is not None:
+        assert layer in {"domain", "application"}, (
+            f"application must not import {name!r} ({path})"
+        )
+
+
+def test_application_depends_only_on_domain() -> None:
     for path in _python_files("application"):
         _assert_no_legacy(path)
         for name in _import_names(path):
-            root = name.split(".")[0]
-            assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
-            assert root not in REPO_OWNED_PACKAGE_ROOTS, (
-                f"application must not import repository package {root!r} ({path})"
-            )
-            if name == "statblocks_v1":
-                continue
-            layer = _layer_of(name)
-            assert layer in {"domain", "application"}, (
-                f"application must not import {name!r} ({path})"
-            )
+            _assert_application_import(name, path=path)
+
+
+def test_application_import_policy_allows_stdlib_pydantic_rejects_outer_layers() -> None:
+    """Stdlib/Pydantic must pass; application → infrastructure/api must fail."""
+    for allowed in (
+        "typing",
+        "datetime",
+        "pydantic",
+        "statblocks_v1",
+        "statblocks_v1.domain",
+        "statblocks_v1.domain.errors",
+        "statblocks_v1.application",
+    ):
+        _assert_application_import(allowed)
+
+    for forbidden in (
+        "statblocks_v1.infrastructure",
+        "statblocks_v1.infrastructure.runtime",
+        "statblocks_v1.api",
+        "statblocks_v1.api.router",
+        "statblocks_v1.testing",
+    ):
+        with pytest.raises(AssertionError):
+            _assert_application_import(forbidden)
 
 
 def test_infrastructure_depends_only_on_domain_and_application() -> None:

--- a/tests/statblocks_v1/test_import_boundaries.py
+++ b/tests/statblocks_v1/test_import_boundaries.py
@@ -1,0 +1,75 @@
+"""Guardrails for statblocks_v1 package dependency direction."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "statblocks_v1"
+
+
+def _module_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".")[0])
+            if node.module.startswith("statblocks_v1"):
+                imports.add(node.module)
+    return imports
+
+
+def _python_files(relative: str) -> list[Path]:
+    return sorted((PACKAGE_ROOT / relative).rglob("*.py"))
+
+
+def test_domain_imports_only_stdlib_and_pydantic() -> None:
+    allowed_roots = {
+        "__future__",
+        "annotations",
+        "typing",
+        "dataclasses",
+        "datetime",
+        "enum",
+        "abc",
+        "collections",
+        "functools",
+        "itertools",
+        "re",
+        "math",
+        "decimal",
+        "uuid",
+        "json",
+        "pydantic",
+        "statblocks_v1",
+    }
+    forbidden_substrings = (
+        "fastapi",
+        "openai",
+        "firebase",
+        "firestore",
+        "statblockgenerator",
+        "cloudflare",
+        "routers",
+    )
+
+    for path in _python_files("domain"):
+        imports = _module_imports(path)
+        for name in imports:
+            assert not any(bad in name for bad in forbidden_substrings), (
+                f"{path} imports forbidden module {name!r}"
+            )
+            root = name.split(".")[0]
+            assert root in allowed_roots or name.startswith("statblocks_v1.domain"), (
+                f"{path} imports unexpected root {root!r}"
+            )
+
+
+def test_api_does_not_import_legacy_statblockgenerator() -> None:
+    for path in _python_files("api"):
+        text = path.read_text()
+        assert "statblockgenerator" not in text
+        assert "StatBlockDetails" not in text

--- a/tests/statblocks_v1/test_import_boundaries.py
+++ b/tests/statblocks_v1/test_import_boundaries.py
@@ -1,4 +1,17 @@
-"""Guardrails for statblocks_v1 package dependency direction."""
+"""Guardrails for statblocks_v1 package dependency direction.
+
+Declared graph:
+
+- domain → standard library and Pydantic only
+- application → domain
+- infrastructure → domain / application (plus external SDKs later)
+- api → domain / application and FastAPI
+
+Narrow exception: ``api`` may import ``routers.internal_auth`` for shared
+internal-key constant names only (not legacy generator packages). The
+foundation prefers local mirrors of those constants so focused tests avoid
+``routers`` package side effects.
+"""
 
 from __future__ import annotations
 
@@ -7,18 +20,47 @@ from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "statblocks_v1"
 
+STDLIB_AND_TYPING_ROOTS = {
+    "__future__",
+    "annotations",
+    "typing",
+    "dataclasses",
+    "datetime",
+    "enum",
+    "abc",
+    "collections",
+    "functools",
+    "itertools",
+    "re",
+    "math",
+    "decimal",
+    "uuid",
+    "json",
+    "os",
+    "sys",
+    "secrets",
+    "hashlib",
+    "unicodedata",
+    "pathlib",
+    "copy",
+}
 
-def _module_imports(path: Path) -> set[str]:
-    tree = ast.parse(path.read_text())
+FORBIDDEN_LEGACY = (
+    "statblockgenerator",
+    "StatBlockDetails",
+)
+
+
+def _import_names(path: Path) -> set[str]:
+    """Return fully-qualified import module names referenced by ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     imports: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                imports.add(alias.name.split(".")[0])
+                imports.add(alias.name)
         elif isinstance(node, ast.ImportFrom) and node.module:
-            imports.add(node.module.split(".")[0])
-            if node.module.startswith("statblocks_v1"):
-                imports.add(node.module)
+            imports.add(node.module)
     return imports
 
 
@@ -26,50 +68,114 @@ def _python_files(relative: str) -> list[Path]:
     return sorted((PACKAGE_ROOT / relative).rglob("*.py"))
 
 
-def test_domain_imports_only_stdlib_and_pydantic() -> None:
-    allowed_roots = {
-        "__future__",
-        "annotations",
-        "typing",
-        "dataclasses",
-        "datetime",
-        "enum",
-        "abc",
-        "collections",
-        "functools",
-        "itertools",
-        "re",
-        "math",
-        "decimal",
-        "uuid",
-        "json",
-        "pydantic",
-        "statblocks_v1",
-    }
-    forbidden_substrings = (
-        "fastapi",
-        "openai",
-        "firebase",
-        "firestore",
-        "statblockgenerator",
-        "cloudflare",
-        "routers",
-    )
+def _assert_no_legacy(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for token in FORBIDDEN_LEGACY:
+        assert token not in text, f"{path} contains forbidden token {token!r}"
 
+
+def _layer_of(module: str) -> str | None:
+    if not module.startswith("statblocks_v1"):
+        return None
+    parts = module.split(".")
+    if len(parts) == 1:
+        return "package_root"
+    if parts[1] in {"domain", "application", "infrastructure", "api"}:
+        return parts[1]
+    return "package_root"
+
+
+def test_domain_imports_only_stdlib_and_pydantic() -> None:
+    allowed_roots = STDLIB_AND_TYPING_ROOTS | {"pydantic", "statblocks_v1"}
     for path in _python_files("domain"):
-        imports = _module_imports(path)
-        for name in imports:
-            assert not any(bad in name for bad in forbidden_substrings), (
-                f"{path} imports forbidden module {name!r}"
-            )
+        _assert_no_legacy(path)
+        for name in _import_names(path):
             root = name.split(".")[0]
-            assert root in allowed_roots or name.startswith("statblocks_v1.domain"), (
-                f"{path} imports unexpected root {root!r}"
+            assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
+            layer = _layer_of(name)
+            if layer is not None:
+                assert layer in {"domain", "package_root"}, (
+                    f"{path} must not import layer {layer!r} ({name})"
+                )
+
+
+def test_application_depends_only_on_domain() -> None:
+    allowed_roots = STDLIB_AND_TYPING_ROOTS | {"pydantic", "statblocks_v1"}
+    for path in _python_files("application"):
+        _assert_no_legacy(path)
+        for name in _import_names(path):
+            root = name.split(".")[0]
+            assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
+            layer = _layer_of(name)
+            if layer is not None:
+                assert layer in {"domain", "application", "package_root"}, (
+                    f"application must not import layer {layer!r} ({path} → {name})"
+                )
+
+
+def test_infrastructure_depends_only_on_domain_and_application() -> None:
+    # SDKs are allowed later; forbid upward imports into api and legacy packages.
+    forbidden_roots = {"fastapi", "statblockgenerator"}
+    for path in _python_files("infrastructure"):
+        _assert_no_legacy(path)
+        for name in _import_names(path):
+            root = name.split(".")[0]
+            assert root not in forbidden_roots, f"{path} imports forbidden root {root!r}"
+            layer = _layer_of(name)
+            if layer is not None:
+                assert layer in {"domain", "application", "infrastructure", "package_root"}, (
+                    f"infrastructure must not import layer {layer!r} ({path} → {name})"
+                )
+            assert not name.startswith("statblocks_v1.api"), (
+                f"infrastructure must not import api ({path} → {name})"
             )
+
+
+def test_api_depends_on_domain_application_fastapi_and_auth_constants() -> None:
+    allowed_roots = STDLIB_AND_TYPING_ROOTS | {
+        "pydantic",
+        "fastapi",
+        "statblocks_v1",
+        "routers",
+    }
+    for path in _python_files("api"):
+        _assert_no_legacy(path)
+        for name in _import_names(path):
+            root = name.split(".")[0]
+            assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
+            layer = _layer_of(name)
+            if layer is not None:
+                assert layer in {"domain", "application", "api", "package_root"}, (
+                    f"api must not import layer {layer!r} ({path} → {name})"
+                )
+            if root == "routers":
+                assert name == "routers.internal_auth", (
+                    f"api may only import routers.internal_auth for shared key constants "
+                    f"({path} → {name})"
+                )
 
 
 def test_api_does_not_import_legacy_statblockgenerator() -> None:
     for path in _python_files("api"):
-        text = path.read_text()
-        assert "statblockgenerator" not in text
-        assert "StatBlockDetails" not in text
+        _assert_no_legacy(path)
+
+
+def test_internal_auth_constants_match_shared_module() -> None:
+    """Wire-contract drift guard without importing the routers package at runtime."""
+    from pathlib import Path as _Path
+
+    import ast as _ast
+
+    from statblocks_v1.api.dependencies import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
+
+    shared = _Path(__file__).resolve().parents[2] / "routers" / "internal_auth.py"
+    tree = _ast.parse(shared.read_text(encoding="utf-8"))
+    values: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, _ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, _ast.Name) and isinstance(node.value, _ast.Constant):
+                if isinstance(node.value.value, str):
+                    values[target.id] = node.value.value
+    assert values.get("INTERNAL_KEY_HEADER") == INTERNAL_KEY_HEADER
+    assert values.get("INTERNAL_KEY_ENV") == INTERNAL_KEY_ENV

--- a/tests/statblocks_v1/test_import_boundaries.py
+++ b/tests/statblocks_v1/test_import_boundaries.py
@@ -3,14 +3,16 @@
 Declared graph:
 
 - domain → standard library and Pydantic only
-- application → domain
-- infrastructure → domain / application (plus external SDKs later)
+- application → domain (and bare ``statblocks_v1`` package root)
+- infrastructure → domain / application plus external SDKs
 - api → domain / application and FastAPI
 
-Narrow exception: ``api`` may import ``routers.internal_auth`` for shared
-internal-key constant names only (not legacy generator packages). The
-foundation prefers local mirrors of those constants so focused tests avoid
-``routers`` package side effects.
+Repository-owned packages (``app``, ``routers``, ``firestore``, …) are rejected
+by default. Infrastructure may reuse them only through explicit
+adapter-specific exceptions.
+
+``statblocks_v1/__init__.py`` must stay domain-safe: domain and application may
+import the bare package root for contract metadata.
 """
 
 from __future__ import annotations
@@ -18,7 +20,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "statblocks_v1"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "statblocks_v1"
 
 STDLIB_AND_TYPING_ROOTS = {
     "__future__",
@@ -49,6 +52,39 @@ FORBIDDEN_LEGACY = (
     "statblockgenerator",
     "StatBlockDetails",
 )
+
+# Relative path under infrastructure/ → allowed repo-owned import roots.
+# Empty in PR12; later adapters opt in explicitly (e.g. firestore client wrap).
+INFRASTRUCTURE_ADAPTER_EXCEPTIONS: dict[str, frozenset[str]] = {}
+
+
+def _repo_owned_package_roots() -> frozenset[str]:
+    """Top-level Python packages/modules owned by this repository (not third-party)."""
+    roots: set[str] = set()
+    skip_dirs = {
+        "statblocks_v1",
+        "tests",
+        "scripts",
+        "Docs",
+        "static",
+        "build",
+        "dungeonmind.egg-info",
+        "__pycache__",
+    }
+    for path in REPO_ROOT.iterdir():
+        if path.name.startswith("."):
+            continue
+        if path.is_dir():
+            if path.name in skip_dirs:
+                continue
+            if (path / "__init__.py").exists() or any(path.glob("*.py")):
+                roots.add(path.name)
+        elif path.is_file() and path.suffix == ".py" and path.name != "__init__.py":
+            roots.add(path.stem)
+    return frozenset(roots)
+
+
+REPO_OWNED_PACKAGE_ROOTS = _repo_owned_package_roots()
 
 
 def _import_names(path: Path) -> set[str]:
@@ -82,21 +118,55 @@ def _layer_of(module: str) -> str | None:
         return "package_root"
     if parts[1] in {"domain", "application", "infrastructure", "api"}:
         return parts[1]
-    return "package_root"
+    # Sibling modules under the package (e.g. testing) are not the domain-safe root.
+    return "package_other"
+
+
+def _assert_domain_safe_imports(path: Path) -> None:
+    allowed_roots = STDLIB_AND_TYPING_ROOTS | {"pydantic", "statblocks_v1"}
+    for name in _import_names(path):
+        root = name.split(".")[0]
+        assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
+        assert root not in REPO_OWNED_PACKAGE_ROOTS, (
+            f"{path} must not import repository package {root!r}"
+        )
+        if not name.startswith("statblocks_v1"):
+            continue
+        if name == "statblocks_v1":
+            continue
+        layer = _layer_of(name)
+        assert layer == "domain", (
+            f"{path} may only import bare statblocks_v1 or statblocks_v1.domain.* "
+            f"(got {name!r})"
+        )
+
+
+def test_repo_owned_roots_include_known_legacy_surfaces() -> None:
+    for expected in (
+        "app",
+        "routers",
+        "firestore",
+        "cloudflare",
+        "ruleslawyer",
+        "cardgenerator",
+        "statblockgenerator",
+    ):
+        assert expected in REPO_OWNED_PACKAGE_ROOTS, (
+            f"expected repository-owned root {expected!r} in {sorted(REPO_OWNED_PACKAGE_ROOTS)}"
+        )
+    assert "statblocks_v1" not in REPO_OWNED_PACKAGE_ROOTS
+
+
+def test_package_root_init_is_domain_safe() -> None:
+    path = PACKAGE_ROOT / "__init__.py"
+    _assert_no_legacy(path)
+    _assert_domain_safe_imports(path)
 
 
 def test_domain_imports_only_stdlib_and_pydantic() -> None:
-    allowed_roots = STDLIB_AND_TYPING_ROOTS | {"pydantic", "statblocks_v1"}
     for path in _python_files("domain"):
         _assert_no_legacy(path)
-        for name in _import_names(path):
-            root = name.split(".")[0]
-            assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
-            layer = _layer_of(name)
-            if layer is not None:
-                assert layer in {"domain", "package_root"}, (
-                    f"{path} must not import layer {layer!r} ({name})"
-                )
+        _assert_domain_safe_imports(path)
 
 
 def test_application_depends_only_on_domain() -> None:
@@ -106,29 +176,44 @@ def test_application_depends_only_on_domain() -> None:
         for name in _import_names(path):
             root = name.split(".")[0]
             assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
+            assert root not in REPO_OWNED_PACKAGE_ROOTS, (
+                f"application must not import repository package {root!r} ({path})"
+            )
+            if name == "statblocks_v1":
+                continue
             layer = _layer_of(name)
-            if layer is not None:
-                assert layer in {"domain", "application", "package_root"}, (
-                    f"application must not import layer {layer!r} ({path} → {name})"
-                )
+            assert layer in {"domain", "application"}, (
+                f"application must not import {name!r} ({path})"
+            )
 
 
 def test_infrastructure_depends_only_on_domain_and_application() -> None:
-    # SDKs are allowed later; forbid upward imports into api and legacy packages.
-    forbidden_roots = {"fastapi", "statblockgenerator"}
+    allowed_layer = {"domain", "application", "infrastructure"}
     for path in _python_files("infrastructure"):
         _assert_no_legacy(path)
+        relative = str(path.relative_to(PACKAGE_ROOT / "infrastructure"))
+        allowed_repo = INFRASTRUCTURE_ADAPTER_EXCEPTIONS.get(relative, frozenset())
         for name in _import_names(path):
             root = name.split(".")[0]
-            assert root not in forbidden_roots, f"{path} imports forbidden root {root!r}"
+            if root in REPO_OWNED_PACKAGE_ROOTS:
+                assert root in allowed_repo, (
+                    f"infrastructure must not import repository package {root!r} "
+                    f"unless listed in INFRASTRUCTURE_ADAPTER_EXCEPTIONS "
+                    f"({path} → {name}; allowed for this file: {sorted(allowed_repo)})"
+                )
+                continue
+            if name == "statblocks_v1":
+                continue
             layer = _layer_of(name)
             if layer is not None:
-                assert layer in {"domain", "application", "infrastructure", "package_root"}, (
+                assert layer in allowed_layer, (
                     f"infrastructure must not import layer {layer!r} ({path} → {name})"
                 )
             assert not name.startswith("statblocks_v1.api"), (
                 f"infrastructure must not import api ({path} → {name})"
             )
+            # FastAPI belongs to the api layer, not infrastructure adapters.
+            assert root != "fastapi", f"{path} must not import fastapi"
 
 
 def test_api_depends_on_domain_application_fastapi_and_auth_constants() -> None:
@@ -143,15 +228,18 @@ def test_api_depends_on_domain_application_fastapi_and_auth_constants() -> None:
         for name in _import_names(path):
             root = name.split(".")[0]
             assert root in allowed_roots, f"{path} imports unexpected root {root!r} ({name})"
-            layer = _layer_of(name)
-            if layer is not None:
-                assert layer in {"domain", "application", "api", "package_root"}, (
-                    f"api must not import layer {layer!r} ({path} → {name})"
-                )
-            if root == "routers":
+            if root in REPO_OWNED_PACKAGE_ROOTS:
                 assert name == "routers.internal_auth", (
                     f"api may only import routers.internal_auth for shared key constants "
                     f"({path} → {name})"
+                )
+                continue
+            if name == "statblocks_v1":
+                continue
+            layer = _layer_of(name)
+            if layer is not None:
+                assert layer in {"domain", "application", "api"}, (
+                    f"api must not import layer {layer!r} ({path} → {name})"
                 )
 
 
@@ -162,19 +250,15 @@ def test_api_does_not_import_legacy_statblockgenerator() -> None:
 
 def test_internal_auth_constants_match_shared_module() -> None:
     """Wire-contract drift guard without importing the routers package at runtime."""
-    from pathlib import Path as _Path
-
-    import ast as _ast
-
     from statblocks_v1.api.dependencies import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
 
-    shared = _Path(__file__).resolve().parents[2] / "routers" / "internal_auth.py"
-    tree = _ast.parse(shared.read_text(encoding="utf-8"))
+    shared = REPO_ROOT / "routers" / "internal_auth.py"
+    tree = ast.parse(shared.read_text(encoding="utf-8"))
     values: dict[str, str] = {}
     for node in tree.body:
-        if isinstance(node, _ast.Assign) and len(node.targets) == 1:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
             target = node.targets[0]
-            if isinstance(target, _ast.Name) and isinstance(node.value, _ast.Constant):
+            if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
                 if isinstance(node.value.value, str):
                     values[target.id] = node.value.value
     assert values.get("INTERNAL_KEY_HEADER") == INTERNAL_KEY_HEADER


### PR DESCRIPTION
## Summary
- Add `statblocks_v1` bounded context (`domain` / `application` / `infrastructure` / `api`) with dependency seams for later PRs.
- Mount `GET /api/internal/dungeonbuddy/v1/statblocks/health` behind router-level DungeonBuddy internal-key auth with a **top-level** typed `ErrorEnvelopeV1` (401/403/503 via exception handlers; misconfigured key env → 503).
- Provide `statblocks_v1.testing.create_test_app()` and a **project-independent** focused test lane.
- AST guards cover the full declared dependency graph (repo-owned packages denied in infrastructure by default); empty protocols are not `@runtime_checkable`; `statblocks_v1/__init__.py` is domain-safe.

## Review follow-ups
1. **Import isolation** — `--confcutdir=tests/statblocks_v1` so `tests/conftest.py` cannot preload `app`.
2. **Dependency isolation** — advertised lane is `./scripts/run_statblocks_v1_tests.sh` (`uv run --isolated --no-project --with pytest/fastapi/pydantic/httpx …`). Ephemeral env (not `.venv`); probe proves openai/firebase/google/fal/sentence_transformers/generationengine are absent.
3. **Import graph** — full layer guards; infrastructure rejects `app`/`routers`/`firestore`/… unless listed in `INFRASTRUCTURE_ADAPTER_EXCEPTIONS`; package root `__init__.py` domain-safe.
4. **Protocols** — placeholders not `@runtime_checkable`.
5. **Typed error envelope** — top-level `{ "error": { ... } }`; OpenAPI 401/403/503; missing config → 503.

## Stack
This is **PR12** of the PR12–PR21 DungeonBuddy statblock v1 series. Successor branches will stack on this head.

## Test plan
- [x] `./scripts/run_statblocks_v1_tests.sh` (19 passed; credentials unset)
- [ ] Spot-check health via isolated app with `DUNGEONBUDDY_INTERNAL_API_KEY` set
- [ ] Confirm legacy `/api/statblockgenerator/*` routes unchanged

Made with [Cursor](https://cursor.com)