### PR TITLE
feat(statblocks_v1): PR15 repositories and immutable persistence

### DIFF
--- a/Docs/Plans/HANDOFF-pr15-statblock-v1-repositories-persistence.md
+++ b/Docs/Plans/HANDOFF-pr15-statblock-v1-repositories-persistence.md
@@ -243,8 +243,10 @@ Define typed domain/application errors for at least:
 - stale parent revision (CAS failure);
 - immutable revision/resource conflict;
 - idempotency conflict;
-- persistence unavailable;
-- transaction indeterminate/reconciliation required.
+- persistence unavailable (non-transaction reads/connectivity);
+- transaction indeterminate/reconciliation required (deadline/transport after a
+  transactional create/append attempt; reconcile via idempotency or fail closed);
+- ambiguous request payload (NFC-colliding map keys in request digests).
 
 Infrastructure exceptions must not leak as raw HTTP details later.
 

--- a/Docs/Plans/HANDOFF-pr15-statblock-v1-repositories-persistence.md
+++ b/Docs/Plans/HANDOFF-pr15-statblock-v1-repositories-persistence.md
@@ -182,9 +182,11 @@ Atomically:
 1. verify idempotency key;
 2. load logical statblock;
 3. verify parent revision exists and belongs to statblock;
-4. write new immutable revision;
-5. update chronological `latest_revision_id`;
-6. write idempotency outcome.
+4. compare-and-swap: submitted parent must equal current `latest_revision_id`
+   (stale parents raise `stale_parent_revision`, distinct from missing/foreign parent);
+5. write new immutable revision;
+6. update chronological `latest_revision_id`;
+7. write idempotency outcome.
 
 Do not overwrite a revision document even when the caller supplies the same ID. IDs are server-owned.
 
@@ -194,7 +196,7 @@ Required behavior:
 
 ```text
 same key + same request digest
-  → return original successful outcome
+  → return original successful outcome (exact statblock_id + revision_id)
 
 same key + different request digest
   → typed idempotency conflict
@@ -203,7 +205,13 @@ retry after partial infrastructure error
   → reconcile transaction outcome before creating anything new
 ```
 
-The request digest is not the definition digest alone; it should distinguish create/append operation parameters and parent/candidate intent.
+Create outcomes must pin the original created revision, not `latest_revision_id`.
+Replay checks the idempotency record before persistence validation/ID allocation, with
+an atomic recheck at commit.
+
+The request digest is not the definition digest alone. It hashes operation parameters
+with the definition component as PR14 canonical JSON and NFC-normalized remaining
+strings so Unicode/set-order equivalents do not false-conflict.
 
 ## 6. Candidate persistence
 
@@ -232,7 +240,8 @@ Define typed domain/application errors for at least:
 - statblock not found;
 - revision not found;
 - parent revision mismatch;
-- immutable revision conflict;
+- stale parent revision (CAS failure);
+- immutable revision/resource conflict;
 - idempotency conflict;
 - persistence unavailable;
 - transaction indeterminate/reconciliation required.

--- a/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
+++ b/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
@@ -15,10 +15,15 @@
 - Candidate IDs use `cand_<base36>`; statblock/revision IDs use `sb_<base36>` and
   `rev_<base36>`. Candidate TTL is enforced by `expires_at`; Firestore TTL must also
   be configured on that field.
-- `compute_request_digest(operation, payload)` covers complete operation parameters;
-  it is distinct from the definition digest. Firestore collections are
-  `dungeonbuddy_statblock_candidates_v1`, `dungeonbuddy_statblocks_v1` with
-  `revisions` subcollections, and `dungeonbuddy_statblock_idempotency_v1`.
+- `compute_request_digest(operation, payload)` covers complete operation parameters
+  with the definition component as PR14 canonical JSON plus NFC-normalized remaining
+  strings; it is distinct from the definition digest.
+  Create/append idempotency outcomes pin `IdempotencyOutcomeV1(statblock_id, revision_id)`
+  so create replay returns the original revision after later appends.
+  Append is compare-and-swap against `latest_revision_id` (`stale_parent_revision`).
+  Firestore collections are `dungeonbuddy_statblock_candidates_v1`,
+  `dungeonbuddy_statblocks_v1` with `revisions` subcollections, and
+  `dungeonbuddy_statblock_idempotency_v1`. Candidate `expires_at` is a native timestamp.
 
 ## 0. Mission
 

--- a/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
+++ b/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
@@ -5,6 +5,21 @@
 **Predecessors:** PR13 contract, PR14 trust core, PR15 repository protocols  
 **Successor:** `HANDOFF-pr17-statblock-v1-candidate-api.md`
 
+## PR15 predecessor completion notes
+
+- Use synchronous `CandidateRepository.create/get` and `StatblockPersistenceRepository`
+  (`create_statblock`, `append_revision`, `get`, `get_revision`); async callers must
+  offload calls with `asyncio.to_thread`.
+- Offline fixtures can use `InMemoryCandidateRepository` and
+  `InMemoryStatblockPersistenceRepository(clock=..., id_factory=DeterministicIdFactory())`.
+- Candidate IDs use `cand_<base36>`; statblock/revision IDs use `sb_<base36>` and
+  `rev_<base36>`. Candidate TTL is enforced by `expires_at`; Firestore TTL must also
+  be configured on that field.
+- `compute_request_digest(operation, payload)` covers complete operation parameters;
+  it is distinct from the definition digest. Firestore collections are
+  `dungeonbuddy_statblock_candidates_v1`, `dungeonbuddy_statblocks_v1` with
+  `revisions` subcollections, and `dungeonbuddy_statblock_idempotency_v1`.
+
 ## 0. Mission
 
 Implement the provider-independent application service that generates and revises `StatblockDefinitionV1` using OpenAI Structured Outputs, validates the result, persists a server-owned candidate record, and returns `GeneratedStatblockCandidateV1`.

--- a/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
+++ b/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
@@ -5,6 +5,19 @@
 **Predecessors:** repository persistence and generation service  
 **Successor:** `HANDOFF-pr18-statblock-v1-revision-resource-api.md`
 
+## PR15 predecessor completion notes
+
+- Use the synchronous repository protocols from `statblocks_v1.application.repositories`;
+  route/service code must use `await asyncio.to_thread(...)` for Firestore calls.
+- `InMemoryCandidateRepository` and `InMemoryStatblockPersistenceRepository` accept
+  deterministic clock and ID fixtures. IDs are `cand_<base36>`, `sb_<base36>`, and
+  `rev_<base36>`.
+- Candidates expire at `expires_at` (also the Firestore TTL field). Collections are
+  `dungeonbuddy_statblock_candidates_v1`, `dungeonbuddy_statblocks_v1/revisions`,
+  and `dungeonbuddy_statblock_idempotency_v1`.
+- Reuse `compute_request_digest(operation, payload)` for request replay: it includes
+  operation parameters rather than using only the mechanics definition digest.
+
 ## 0. Mission
 
 Expose the generation, revision, validation, and candidate-read operations through the dedicated authenticated DungeonBuddy v1 router.

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,4 @@ markers =
     live: marks tests that require live API calls
     unit: marks tests as unit tests
     asyncio: marks tests as async tests
+    firestore_emulator: requires FIRESTORE_EMULATOR_HOST and a Firestore emulator

--- a/statblocks_v1/application/repositories.py
+++ b/statblocks_v1/application/repositories.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import unicodedata
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from datetime import datetime
 from typing import Any, Protocol
 
@@ -95,6 +96,19 @@ class StatblockPersistenceRepository(
 
 
 class CreateStatblockCommand:
+    """Immutable create intent: inputs are snapshotted and the digest is fixed."""
+
+    __slots__ = (
+        "caller_scope",
+        "idempotency_key",
+        "created_by",
+        "candidate_id",
+        "_definition",
+        "_provenance",
+        "_asset_bindings",
+        "_request_digest",
+    )
+
     def __init__(
         self,
         *,
@@ -106,29 +120,65 @@ class CreateStatblockCommand:
         asset_bindings: list[dict[str, Any]] | None = None,
         candidate_id: str | None = None,
     ) -> None:
-        self.caller_scope = caller_scope
-        self.idempotency_key = idempotency_key
-        self.definition = definition
-        self.created_by = created_by
-        self.provenance = provenance or {}
-        self.asset_bindings = asset_bindings or []
-        self.candidate_id = candidate_id
+        object.__setattr__(self, "caller_scope", caller_scope)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+        object.__setattr__(self, "created_by", created_by)
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "_definition", definition.model_copy(deep=True))
+        object.__setattr__(self, "_provenance", deepcopy(provenance or {}))
+        object.__setattr__(self, "_asset_bindings", deepcopy(asset_bindings or []))
+        object.__setattr__(
+            self,
+            "_request_digest",
+            compute_request_digest(
+                "create_statblock",
+                {
+                    "definition_canonical": str(
+                        canonicalize_definition(self._definition)
+                    ),
+                    "created_by": created_by,
+                    "provenance": self._provenance,
+                    "asset_bindings": self._asset_bindings,
+                    "candidate_id": candidate_id,
+                },
+            ),
+        )
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("CreateStatblockCommand is immutable after construction")
+
+    @property
+    def definition(self) -> StatblockDefinitionV1:
+        return self._definition.model_copy(deep=True)
+
+    @property
+    def provenance(self) -> dict[str, Any]:
+        return deepcopy(self._provenance)
+
+    @property
+    def asset_bindings(self) -> list[dict[str, Any]]:
+        return deepcopy(self._asset_bindings)
 
     @property
     def request_digest(self) -> str:
-        return compute_request_digest(
-            "create_statblock",
-            {
-                "definition_canonical": str(canonicalize_definition(self.definition)),
-                "created_by": self.created_by,
-                "provenance": self.provenance,
-                "asset_bindings": self.asset_bindings,
-                "candidate_id": self.candidate_id,
-            },
-        )
+        return self._request_digest
 
 
 class AppendRevisionCommand:
+    """Immutable append intent: inputs are snapshotted and the digest is fixed."""
+
+    __slots__ = (
+        "caller_scope",
+        "idempotency_key",
+        "statblock_id",
+        "parent_revision_id",
+        "candidate_id",
+        "_definition",
+        "_provenance",
+        "_asset_bindings",
+        "_request_digest",
+    )
+
     def __init__(
         self,
         *,
@@ -141,28 +191,50 @@ class AppendRevisionCommand:
         asset_bindings: list[dict[str, Any]] | None = None,
         candidate_id: str | None = None,
     ) -> None:
-        self.caller_scope = caller_scope
-        self.idempotency_key = idempotency_key
-        self.statblock_id = statblock_id
-        self.parent_revision_id = parent_revision_id
-        self.definition = definition
-        self.provenance = provenance or {}
-        self.asset_bindings = asset_bindings or []
-        self.candidate_id = candidate_id
+        object.__setattr__(self, "caller_scope", caller_scope)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+        object.__setattr__(self, "statblock_id", statblock_id)
+        object.__setattr__(self, "parent_revision_id", parent_revision_id)
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "_definition", definition.model_copy(deep=True))
+        object.__setattr__(self, "_provenance", deepcopy(provenance or {}))
+        object.__setattr__(self, "_asset_bindings", deepcopy(asset_bindings or []))
+        object.__setattr__(
+            self,
+            "_request_digest",
+            compute_request_digest(
+                "append_revision",
+                {
+                    "statblock_id": statblock_id,
+                    "parent_revision_id": parent_revision_id,
+                    "definition_canonical": str(
+                        canonicalize_definition(self._definition)
+                    ),
+                    "provenance": self._provenance,
+                    "asset_bindings": self._asset_bindings,
+                    "candidate_id": candidate_id,
+                },
+            ),
+        )
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("AppendRevisionCommand is immutable after construction")
+
+    @property
+    def definition(self) -> StatblockDefinitionV1:
+        return self._definition.model_copy(deep=True)
+
+    @property
+    def provenance(self) -> dict[str, Any]:
+        return deepcopy(self._provenance)
+
+    @property
+    def asset_bindings(self) -> list[dict[str, Any]]:
+        return deepcopy(self._asset_bindings)
 
     @property
     def request_digest(self) -> str:
-        return compute_request_digest(
-            "append_revision",
-            {
-                "statblock_id": self.statblock_id,
-                "parent_revision_id": self.parent_revision_id,
-                "definition_canonical": str(canonicalize_definition(self.definition)),
-                "provenance": self.provenance,
-                "asset_bindings": self.asset_bindings,
-                "candidate_id": self.candidate_id,
-            },
-        )
+        return self._request_digest
 
 
 Clock = Callable[[], datetime]

--- a/statblocks_v1/application/repositories.py
+++ b/statblocks_v1/application/repositories.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable
+import unicodedata
+from collections.abc import Callable, Mapping
 from datetime import datetime
 from typing import Any, Protocol
 
+from statblocks_v1.domain.canonicalization import canonicalize_definition
 from statblocks_v1.domain.resources import (
     GeneratedStatblockCandidateV1,
     IdempotencyRecordV1,
@@ -21,14 +23,36 @@ from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 
 
 def compute_request_digest(operation: str, payload: dict[str, Any]) -> str:
-    """Hash all operation parameters, not merely the mechanics definition."""
+    """Hash operation intent with NFC-normalized, order-stable JSON.
+
+    The definition component must already be PR14 canonical JSON text so Unicode
+    and set-like field ordering cannot create false idempotency conflicts.
+    """
+
     canonical = json.dumps(
-        {"operation": operation, "payload": payload},
+        {
+            "operation": operation,
+            "payload": _normalize_request_payload(payload),
+        },
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
+        allow_nan=False,
     ).encode("utf-8")
     return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def _normalize_request_payload(value: Any) -> Any:
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, Mapping):
+        return {
+            unicodedata.normalize("NFC", str(key)): _normalize_request_payload(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, list):
+        return [_normalize_request_payload(item) for item in value]
+    return value
 
 
 class CandidateRepository(Protocol):
@@ -90,7 +114,7 @@ class CreateStatblockCommand:
         return compute_request_digest(
             "create_statblock",
             {
-                "definition": self.definition.model_dump(mode="json"),
+                "definition_canonical": str(canonicalize_definition(self.definition)),
                 "created_by": self.created_by,
                 "provenance": self.provenance,
                 "asset_bindings": self.asset_bindings,
@@ -128,7 +152,7 @@ class AppendRevisionCommand:
             {
                 "statblock_id": self.statblock_id,
                 "parent_revision_id": self.parent_revision_id,
-                "definition": self.definition.model_dump(mode="json"),
+                "definition_canonical": str(canonicalize_definition(self.definition)),
                 "provenance": self.provenance,
                 "asset_bindings": self.asset_bindings,
                 "candidate_id": self.candidate_id,

--- a/statblocks_v1/application/repositories.py
+++ b/statblocks_v1/application/repositories.py
@@ -1,0 +1,139 @@
+"""Transport-neutral synchronous repository protocols and persistence commands.
+
+Firestore's Python client is blocking.  These protocols intentionally expose
+synchronous methods; async API code must call them with ``asyncio.to_thread``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, Protocol
+
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
+    IdempotencyRecordV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+
+def compute_request_digest(operation: str, payload: dict[str, Any]) -> str:
+    """Hash all operation parameters, not merely the mechanics definition."""
+    canonical = json.dumps(
+        {"operation": operation, "payload": payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+class CandidateRepository(Protocol):
+    def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1: ...
+    def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1: ...
+
+
+class StatblockRepository(Protocol):
+    def get(self, statblock_id: str) -> StatblockResourceV1: ...
+
+
+class RevisionRepository(Protocol):
+    def get_revision(self, statblock_id: str, revision_id: str) -> StatblockRevisionResourceV1: ...
+    def list_for_statblock(self, statblock_id: str) -> list[StatblockRevisionResourceV1]: ...
+
+
+class IdempotencyRepository(Protocol):
+    def get_idempotency(
+        self, caller_scope: str, operation: str, idempotency_key: str
+    ) -> IdempotencyRecordV1 | None: ...
+
+
+class StatblockPersistenceRepository(
+    StatblockRepository, RevisionRepository, IdempotencyRepository, Protocol
+):
+    """Atomic create/append boundary implemented by each durable adapter."""
+
+    def create_statblock(
+        self, command: "CreateStatblockCommand"
+    ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]: ...
+
+    def append_revision(
+        self, command: "AppendRevisionCommand"
+    ) -> StatblockRevisionResourceV1: ...
+
+
+class CreateStatblockCommand:
+    def __init__(
+        self,
+        *,
+        caller_scope: str,
+        idempotency_key: str,
+        definition: StatblockDefinitionV1,
+        created_by: str,
+        provenance: dict[str, Any] | None = None,
+        asset_bindings: list[dict[str, Any]] | None = None,
+        candidate_id: str | None = None,
+    ) -> None:
+        self.caller_scope = caller_scope
+        self.idempotency_key = idempotency_key
+        self.definition = definition
+        self.created_by = created_by
+        self.provenance = provenance or {}
+        self.asset_bindings = asset_bindings or []
+        self.candidate_id = candidate_id
+
+    @property
+    def request_digest(self) -> str:
+        return compute_request_digest(
+            "create_statblock",
+            {
+                "definition": self.definition.model_dump(mode="json"),
+                "created_by": self.created_by,
+                "provenance": self.provenance,
+                "asset_bindings": self.asset_bindings,
+                "candidate_id": self.candidate_id,
+            },
+        )
+
+
+class AppendRevisionCommand:
+    def __init__(
+        self,
+        *,
+        caller_scope: str,
+        idempotency_key: str,
+        statblock_id: str,
+        parent_revision_id: str,
+        definition: StatblockDefinitionV1,
+        provenance: dict[str, Any] | None = None,
+        asset_bindings: list[dict[str, Any]] | None = None,
+        candidate_id: str | None = None,
+    ) -> None:
+        self.caller_scope = caller_scope
+        self.idempotency_key = idempotency_key
+        self.statblock_id = statblock_id
+        self.parent_revision_id = parent_revision_id
+        self.definition = definition
+        self.provenance = provenance or {}
+        self.asset_bindings = asset_bindings or []
+        self.candidate_id = candidate_id
+
+    @property
+    def request_digest(self) -> str:
+        return compute_request_digest(
+            "append_revision",
+            {
+                "statblock_id": self.statblock_id,
+                "parent_revision_id": self.parent_revision_id,
+                "definition": self.definition.model_dump(mode="json"),
+                "provenance": self.provenance,
+                "asset_bindings": self.asset_bindings,
+                "candidate_id": self.candidate_id,
+            },
+        )
+
+
+Clock = Callable[[], datetime]

--- a/statblocks_v1/application/repositories.py
+++ b/statblocks_v1/application/repositories.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Any, Protocol
 
 from statblocks_v1.domain.canonicalization import canonicalize_definition
+from statblocks_v1.domain.errors import AmbiguousRequestPayloadError
 from statblocks_v1.domain.resources import (
     GeneratedStatblockCandidateV1,
     IdempotencyRecordV1,
@@ -27,6 +28,7 @@ def compute_request_digest(operation: str, payload: dict[str, Any]) -> str:
 
     The definition component must already be PR14 canonical JSON text so Unicode
     and set-like field ordering cannot create false idempotency conflicts.
+    Distinct map keys that collide after NFC normalization fail closed.
     """
 
     canonical = json.dumps(
@@ -46,10 +48,13 @@ def _normalize_request_payload(value: Any) -> Any:
     if isinstance(value, str):
         return unicodedata.normalize("NFC", value)
     if isinstance(value, Mapping):
-        return {
-            unicodedata.normalize("NFC", str(key)): _normalize_request_payload(item)
-            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
-        }
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            nfc_key = unicodedata.normalize("NFC", str(key))
+            if nfc_key in normalized:
+                raise AmbiguousRequestPayloadError(nfc_key)
+            normalized[nfc_key] = _normalize_request_payload(item)
+        return {key: normalized[key] for key in sorted(normalized)}
     if isinstance(value, list):
         return [_normalize_request_payload(item) for item in value]
     return value

--- a/statblocks_v1/domain/__init__.py
+++ b/statblocks_v1/domain/__init__.py
@@ -43,6 +43,12 @@ from statblocks_v1.domain.receipts import (
     ValidationStatus,
 )
 from statblocks_v1.domain.rule_elements import Mechanic, RuleElement, StatblockDefinitionV1
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
+    IdempotencyRecordV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
 from statblocks_v1.domain.validation import validate_definition
 
 __all__ = [
@@ -60,6 +66,8 @@ __all__ = [
     "Distance",
     "Duration",
     "Effect",
+    "GeneratedStatblockCandidateV1",
+    "IdempotencyRecordV1",
     "LairProfile",
     "Mechanic",
     "MovementProfile",
@@ -71,6 +79,8 @@ __all__ = [
     "RulesetRef",
     "SenseProfile",
     "StatblockDefinitionV1",
+    "StatblockResourceV1",
+    "StatblockRevisionResourceV1",
     "StatblockFlavorText",
     "TargetProfile",
     "Trigger",

--- a/statblocks_v1/domain/__init__.py
+++ b/statblocks_v1/domain/__init__.py
@@ -45,6 +45,7 @@ from statblocks_v1.domain.receipts import (
 from statblocks_v1.domain.rule_elements import Mechanic, RuleElement, StatblockDefinitionV1
 from statblocks_v1.domain.resources import (
     GeneratedStatblockCandidateV1,
+    IdempotencyOutcomeV1,
     IdempotencyRecordV1,
     StatblockResourceV1,
     StatblockRevisionResourceV1,
@@ -67,6 +68,7 @@ __all__ = [
     "Duration",
     "Effect",
     "GeneratedStatblockCandidateV1",
+    "IdempotencyOutcomeV1",
     "IdempotencyRecordV1",
     "LairProfile",
     "Mechanic",

--- a/statblocks_v1/domain/errors.py
+++ b/statblocks_v1/domain/errors.py
@@ -63,9 +63,34 @@ class ParentRevisionMismatchError(StatblockV1Error):
         )
 
 
-class ImmutableRevisionConflictError(StatblockV1Error):
-    def __init__(self, revision_id: str) -> None:
+class StaleParentRevisionError(StatblockV1Error):
+    def __init__(
+        self, statblock_id: str, parent_revision_id: str, latest_revision_id: str
+    ) -> None:
         super().__init__(
+            "stale_parent_revision",
+            "Parent revision is not the current latest revision",
+            {
+                "statblock_id": statblock_id,
+                "parent_revision_id": parent_revision_id,
+                "latest_revision_id": latest_revision_id,
+            },
+        )
+
+
+class ImmutableResourceConflictError(StatblockV1Error):
+    def __init__(self, resource_type: str, resource_id: str) -> None:
+        super().__init__(
+            "immutable_resource_conflict",
+            f"{resource_type} IDs are server-owned and immutable",
+            {"resource_type": resource_type, "resource_id": resource_id},
+        )
+
+
+class ImmutableRevisionConflictError(ImmutableResourceConflictError):
+    def __init__(self, revision_id: str) -> None:
+        StatblockV1Error.__init__(
+            self,
             "immutable_revision_conflict",
             "Revision IDs are server-owned and immutable",
             {"revision_id": revision_id},

--- a/statblocks_v1/domain/errors.py
+++ b/statblocks_v1/domain/errors.py
@@ -106,6 +106,15 @@ class IdempotencyConflictError(StatblockV1Error):
         )
 
 
+class AmbiguousRequestPayloadError(StatblockV1Error):
+    def __init__(self, key: str) -> None:
+        super().__init__(
+            "ambiguous_request_payload",
+            "Request map keys collide after Unicode NFC normalization",
+            {"key": key},
+        )
+
+
 class PersistenceValidationError(StatblockV1Error):
     def __init__(self) -> None:
         super().__init__("validation_failed", "Definition is not persistence-ready")

--- a/statblocks_v1/domain/errors.py
+++ b/statblocks_v1/domain/errors.py
@@ -32,3 +32,68 @@ class InternalServiceMisconfiguredError(StatblockV1Error):
 
     def __init__(self, message: str = "Internal service is misconfigured") -> None:
         super().__init__(code="internal_service_misconfigured", message=message)
+
+
+class CandidateNotFoundError(StatblockV1Error):
+    def __init__(self, candidate_id: str) -> None:
+        super().__init__("candidate_not_found", "Candidate was not found", {"candidate_id": candidate_id})
+
+
+class CandidateExpiredError(StatblockV1Error):
+    def __init__(self, candidate_id: str) -> None:
+        super().__init__("candidate_expired", "Candidate has expired", {"candidate_id": candidate_id})
+
+
+class StatblockNotFoundError(StatblockV1Error):
+    def __init__(self, statblock_id: str) -> None:
+        super().__init__("statblock_not_found", "Statblock was not found", {"statblock_id": statblock_id})
+
+
+class RevisionNotFoundError(StatblockV1Error):
+    def __init__(self, revision_id: str) -> None:
+        super().__init__("revision_not_found", "Revision was not found", {"revision_id": revision_id})
+
+
+class ParentRevisionMismatchError(StatblockV1Error):
+    def __init__(self, statblock_id: str, revision_id: str) -> None:
+        super().__init__(
+            "parent_revision_mismatch",
+            "Parent revision does not belong to this statblock",
+            {"statblock_id": statblock_id, "revision_id": revision_id},
+        )
+
+
+class ImmutableRevisionConflictError(StatblockV1Error):
+    def __init__(self, revision_id: str) -> None:
+        super().__init__(
+            "immutable_revision_conflict",
+            "Revision IDs are server-owned and immutable",
+            {"revision_id": revision_id},
+        )
+
+
+class IdempotencyConflictError(StatblockV1Error):
+    def __init__(self, idempotency_key: str) -> None:
+        super().__init__(
+            "idempotency_conflict",
+            "Idempotency key was reused with a different request",
+            {"idempotency_key": idempotency_key},
+        )
+
+
+class PersistenceValidationError(StatblockV1Error):
+    def __init__(self) -> None:
+        super().__init__("validation_failed", "Definition is not persistence-ready")
+
+
+class PersistenceUnavailableError(StatblockV1Error):
+    def __init__(self) -> None:
+        super().__init__("persistence_unavailable", "Persistence is unavailable")
+
+
+class TransactionIndeterminateError(StatblockV1Error):
+    def __init__(self) -> None:
+        super().__init__(
+            "transaction_indeterminate",
+            "Transaction outcome is indeterminate and requires reconciliation",
+        )

--- a/statblocks_v1/domain/resources.py
+++ b/statblocks_v1/domain/resources.py
@@ -1,0 +1,83 @@
+"""Server-owned resource envelopes for persisted statblock v1 content."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field
+
+from statblocks_v1.domain.primitives import StrictModel
+from statblocks_v1.domain.receipts import ValidationReceiptV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+STATBLOCK_CONTRACT = "dungeonbuddy-statblock"
+STATBLOCK_CONTRACT_VERSION = "v1"
+
+
+class ResourceLocatorV1(StrictModel):
+    resource_type: str = Field(min_length=1)
+    resource_id: str = Field(min_length=1)
+
+
+class GenerationReceiptV1(StrictModel):
+    """Extensible, server-owned audit data populated by the generation service."""
+
+    request_id: str = Field(min_length=1)
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    prompt_version: str = Field(min_length=1)
+    schema_version: str = Field(min_length=1)
+    schema_fingerprint: str = Field(min_length=1)
+    generated_at: datetime
+    source_description_digest: str | None = None
+    source_locator: ResourceLocatorV1 | None = None
+    provider_request_id: str | None = None
+    provider_response_id: str | None = None
+    latency_ms: int | None = Field(default=None, ge=0)
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+
+
+class GeneratedStatblockCandidateV1(StrictModel):
+    candidate_id: str = Field(pattern=r"^cand_[a-z0-9]+$")
+    contract: str = STATBLOCK_CONTRACT
+    contract_version: str = STATBLOCK_CONTRACT_VERSION
+    definition: StatblockDefinitionV1
+    validation_receipt: ValidationReceiptV1
+    generation_receipt: GenerationReceiptV1 | None = None
+    asset_brief: dict[str, Any] | None = None
+    assets: list[dict[str, Any]] = Field(default_factory=list)
+    created_at: datetime
+    expires_at: datetime
+    source_locator: ResourceLocatorV1 | None = None
+
+
+class StatblockResourceV1(StrictModel):
+    statblock_id: str = Field(pattern=r"^sb_[a-z0-9]+$")
+    latest_revision_id: str = Field(pattern=r"^rev_[a-z0-9]+$")
+    created_at: datetime
+    created_by: str = Field(min_length=1)
+
+
+class StatblockRevisionResourceV1(StrictModel):
+    statblock_id: str = Field(pattern=r"^sb_[a-z0-9]+$")
+    revision_id: str = Field(pattern=r"^rev_[a-z0-9]+$")
+    parent_revision_id: str | None = Field(default=None, pattern=r"^rev_[a-z0-9]+$")
+    contract: str = STATBLOCK_CONTRACT
+    contract_version: str = STATBLOCK_CONTRACT_VERSION
+    definition: StatblockDefinitionV1
+    canonical_definition: str = Field(min_length=2)
+    definition_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    validation_receipt: ValidationReceiptV1
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    asset_bindings: list[dict[str, Any]] = Field(default_factory=list)
+    created_at: datetime
+
+
+class IdempotencyRecordV1(StrictModel):
+    caller_scope: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    idempotency_key: str = Field(min_length=1)
+    request_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    outcome: ResourceLocatorV1
+    created_at: datetime

--- a/statblocks_v1/domain/resources.py
+++ b/statblocks_v1/domain/resources.py
@@ -19,6 +19,13 @@ class ResourceLocatorV1(StrictModel):
     resource_id: str = Field(min_length=1)
 
 
+class IdempotencyOutcomeV1(StrictModel):
+    """Exact create/append result pinned for durable replay."""
+
+    statblock_id: str = Field(pattern=r"^sb_[a-z0-9]+$")
+    revision_id: str = Field(pattern=r"^rev_[a-z0-9]+$")
+
+
 class GenerationReceiptV1(StrictModel):
     """Extensible, server-owned audit data populated by the generation service."""
 
@@ -79,5 +86,5 @@ class IdempotencyRecordV1(StrictModel):
     operation: str = Field(min_length=1)
     idempotency_key: str = Field(min_length=1)
     request_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
-    outcome: ResourceLocatorV1
+    outcome: IdempotencyOutcomeV1
     created_at: datetime

--- a/statblocks_v1/infrastructure/firestore_layout.md
+++ b/statblocks_v1/infrastructure/firestore_layout.md
@@ -1,0 +1,24 @@
+# Statblock v1 Firestore layout
+
+Canonical v1 persistence is isolated from legacy statblock collections:
+
+```text
+dungeonbuddy_statblock_candidates_v1/{cand_<base36>}
+dungeonbuddy_statblocks_v1/{sb_<base36>}
+  revisions/{rev_<base36>}
+dungeonbuddy_statblock_idempotency_v1/{sha256(scope, operation, key)}
+```
+
+Candidate documents contain `expires_at`. Configure a Firestore TTL policy on
+`dungeonbuddy_statblock_candidates_v1.expires_at`; TTL cleanup is asynchronous,
+so reads enforce expiration independently. Revisions have no TTL and are never
+updated or deleted by this adapter.
+
+The only expected query is revisions beneath a known statblock. If chronological
+listing is required, add a composite/index configuration for `created_at`
+according to the deployed Firestore project; the current adapter streams the
+subcollection and does not require one.
+
+Firestore's Python client is synchronous. Repository methods intentionally
+remain synchronous; async application/API callers must invoke each operation
+through `asyncio.to_thread`, never directly on the event-loop thread.

--- a/statblocks_v1/infrastructure/firestore_layout.md
+++ b/statblocks_v1/infrastructure/firestore_layout.md
@@ -9,7 +9,8 @@ dungeonbuddy_statblocks_v1/{sb_<base36>}
 dungeonbuddy_statblock_idempotency_v1/{sha256(scope, operation, key)}
 ```
 
-Candidate documents contain `expires_at`. Configure a Firestore TTL policy on
+Candidate documents contain `expires_at` stored as a native Firestore timestamp
+(not a JSON string). Configure a Firestore TTL policy on
 `dungeonbuddy_statblock_candidates_v1.expires_at`; TTL cleanup is asynchronous,
 so reads enforce expiration independently. Revisions have no TTL and are never
 updated or deleted by this adapter.

--- a/statblocks_v1/infrastructure/firestore_repositories.py
+++ b/statblocks_v1/infrastructure/firestore_repositories.py
@@ -59,8 +59,6 @@ class FirestoreCandidateRepository:
         except Exception as error:
             if _is_already_exists(error):
                 raise ImmutableResourceConflictError("candidate", stored.candidate_id) from error
-            if _is_unavailable(error):
-                raise PersistenceUnavailableError() from error
             raise PersistenceUnavailableError() from error
         return stored.model_copy(deep=True)
 
@@ -142,24 +140,28 @@ class FirestoreStatblockPersistenceRepository:
     def create_statblock(
         self, command: CreateStatblockCommand
     ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
+        request_digest = command.request_digest
+        definition = command.definition
+        provenance = command.provenance
+        asset_bindings = command.asset_bindings
         existing = self.get_idempotency(
             command.caller_scope, "create_statblock", command.idempotency_key
         )
         if existing is not None:
-            if existing.request_digest != command.request_digest:
+            if existing.request_digest != request_digest:
                 raise IdempotencyConflictError(command.idempotency_key)
             return (
                 self.get(existing.outcome.statblock_id),
                 self.get_revision(existing.outcome.statblock_id, existing.outcome.revision_id),
             )
 
-        canonical, digest, receipt = _persistence_material(command.definition)
+        canonical, digest, receipt = _persistence_material(definition)
         now = self._clock()
         statblock_id = self._id_factory("sb")
         revision_id = self._id_factory("rev")
-        definition = command.definition.model_copy(deep=True)
-        asset_bindings = deepcopy(command.asset_bindings)
-        provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
+        stored_definition = definition.model_copy(deep=True)
+        stored_bindings = deepcopy(asset_bindings)
+        stored_provenance = deepcopy(_provenance(provenance, command.candidate_id))
         statblock = StatblockResourceV1(
             statblock_id=statblock_id,
             latest_revision_id=revision_id,
@@ -169,12 +171,12 @@ class FirestoreStatblockPersistenceRepository:
         revision = StatblockRevisionResourceV1(
             statblock_id=statblock_id,
             revision_id=revision_id,
-            definition=definition,
+            definition=stored_definition,
             canonical_definition=str(canonical),
             definition_digest=digest,
             validation_receipt=receipt,
-            provenance=provenance,
-            asset_bindings=asset_bindings,
+            provenance=stored_provenance,
+            asset_bindings=stored_bindings,
             created_at=now,
         )
         outcome = IdempotencyOutcomeV1(statblock_id=statblock_id, revision_id=revision_id)
@@ -183,7 +185,7 @@ class FirestoreStatblockPersistenceRepository:
                 command.caller_scope,
                 "create_statblock",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
                 outcome,
                 [
                     (self._document(STATBLOCKS_COLLECTION, statblock_id), _dump(statblock)),
@@ -196,7 +198,7 @@ class FirestoreStatblockPersistenceRepository:
                 command.caller_scope,
                 "create_statblock",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
             )
             return (
                 self.get(reconciled.statblock_id),
@@ -213,40 +215,44 @@ class FirestoreStatblockPersistenceRepository:
         return statblock, revision
 
     def append_revision(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1:
+        request_digest = command.request_digest
+        definition = command.definition
+        provenance = command.provenance
+        asset_bindings = command.asset_bindings
         existing = self.get_idempotency(
             command.caller_scope, "append_revision", command.idempotency_key
         )
         if existing is not None:
-            if existing.request_digest != command.request_digest:
+            if existing.request_digest != request_digest:
                 raise IdempotencyConflictError(command.idempotency_key)
             return self.get_revision(existing.outcome.statblock_id, existing.outcome.revision_id)
 
-        canonical, digest, receipt = _persistence_material(command.definition)
+        canonical, digest, receipt = _persistence_material(definition)
         now = self._clock()
         revision_id = self._id_factory("rev")
-        definition = command.definition.model_copy(deep=True)
-        asset_bindings = deepcopy(command.asset_bindings)
-        provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
+        stored_definition = definition.model_copy(deep=True)
+        stored_bindings = deepcopy(asset_bindings)
+        stored_provenance = deepcopy(_provenance(provenance, command.candidate_id))
         revision = StatblockRevisionResourceV1(
             statblock_id=command.statblock_id,
             revision_id=revision_id,
             parent_revision_id=command.parent_revision_id,
-            definition=definition,
+            definition=stored_definition,
             canonical_definition=str(canonical),
             definition_digest=digest,
             validation_receipt=receipt,
-            provenance=provenance,
-            asset_bindings=asset_bindings,
+            provenance=stored_provenance,
+            asset_bindings=stored_bindings,
             created_at=now,
         )
         try:
-            self._transactional_append(command, revision)
+            self._transactional_append(command, revision, request_digest=request_digest)
         except TransactionIndeterminateError:
             reconciled = self._reconcile_idempotent_outcome(
                 command.caller_scope,
                 "append_revision",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
             )
             return self.get_revision(reconciled.statblock_id, reconciled.revision_id)
         record = self.get_idempotency(
@@ -298,7 +304,11 @@ class FirestoreStatblockPersistenceRepository:
         self._run_transaction(operation_fn, already_exists=already_exists)
 
     def _transactional_append(
-        self, command: AppendRevisionCommand, revision: StatblockRevisionResourceV1
+        self,
+        command: AppendRevisionCommand,
+        revision: StatblockRevisionResourceV1,
+        *,
+        request_digest: str,
     ) -> None:
         from google.cloud.firestore_v1 import transactional
 
@@ -314,7 +324,7 @@ class FirestoreStatblockPersistenceRepository:
             existing = idem_ref.get(transaction=transaction)
             if existing.exists:
                 record = IdempotencyRecordV1.model_validate(existing.to_dict())
-                if record.request_digest != command.request_digest:
+                if record.request_digest != request_digest:
                     raise IdempotencyConflictError(command.idempotency_key)
                 return
 
@@ -344,7 +354,7 @@ class FirestoreStatblockPersistenceRepository:
                         caller_scope=command.caller_scope,
                         operation="append_revision",
                         idempotency_key=command.idempotency_key,
-                        request_digest=command.request_digest,
+                        request_digest=request_digest,
                         outcome=IdempotencyOutcomeV1(
                             statblock_id=command.statblock_id,
                             revision_id=revision.revision_id,

--- a/statblocks_v1/infrastructure/firestore_repositories.py
+++ b/statblocks_v1/infrastructure/firestore_repositories.py
@@ -6,22 +6,37 @@ the event loop.
 """
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Callable
 from uuid import uuid4
 
 from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
 from statblocks_v1.domain.errors import (
-    CandidateExpiredError, CandidateNotFoundError, IdempotencyConflictError,
-    ParentRevisionMismatchError, PersistenceUnavailableError, RevisionNotFoundError,
-    StatblockNotFoundError, TransactionIndeterminateError,
+    CandidateExpiredError,
+    CandidateNotFoundError,
+    IdempotencyConflictError,
+    ImmutableResourceConflictError,
+    ImmutableRevisionConflictError,
+    ParentRevisionMismatchError,
+    PersistenceUnavailableError,
+    RevisionNotFoundError,
+    StaleParentRevisionError,
+    StatblockNotFoundError,
+    TransactionIndeterminateError,
 )
 from statblocks_v1.domain.resources import (
-    GeneratedStatblockCandidateV1, IdempotencyRecordV1, ResourceLocatorV1,
-    StatblockResourceV1, StatblockRevisionResourceV1,
+    GeneratedStatblockCandidateV1,
+    IdempotencyOutcomeV1,
+    IdempotencyRecordV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
 )
 from statblocks_v1.infrastructure.memory_repositories import (
-    _persistence_material, _provenance, utc_now,
+    _persistence_material,
+    _provenance,
+    utc_now,
 )
 
 CANDIDATES_COLLECTION = "dungeonbuddy_statblock_candidates_v1"
@@ -36,11 +51,18 @@ class FirestoreCandidateRepository:
         self._client, self._clock = client, clock
 
     def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1:
+        stored = candidate.model_copy(deep=True)
         try:
-            self._client.collection(CANDIDATES_COLLECTION).document(candidate.candidate_id).create(_dump(candidate))
+            self._client.collection(CANDIDATES_COLLECTION).document(stored.candidate_id).create(
+                _dump(stored)
+            )
         except Exception as error:
+            if _is_already_exists(error):
+                raise ImmutableResourceConflictError("candidate", stored.candidate_id) from error
+            if _is_unavailable(error):
+                raise PersistenceUnavailableError() from error
             raise PersistenceUnavailableError() from error
-        return candidate.model_copy(deep=True)
+        return stored.model_copy(deep=True)
 
     def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1:
         try:
@@ -59,76 +81,172 @@ class FirestoreStatblockPersistenceRepository:
     """Atomic create/append adapter using Firestore read-write transactions."""
 
     def __init__(
-        self, client: Any, *, clock: Callable[[], datetime] = utc_now,
+        self,
+        client: Any,
+        *,
+        clock: Callable[[], datetime] = utc_now,
         id_factory: Callable[[str], str] | None = None,
     ) -> None:
         self._client, self._clock = client, clock
         self._id_factory = id_factory or (lambda prefix: f"{prefix}_{uuid4().hex}")
 
     def get(self, statblock_id: str) -> StatblockResourceV1:
-        snapshot = self._document(STATBLOCKS_COLLECTION, statblock_id).get()
+        try:
+            snapshot = self._document(STATBLOCKS_COLLECTION, statblock_id).get()
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
         if not snapshot.exists:
             raise StatblockNotFoundError(statblock_id)
         return StatblockResourceV1.model_validate(snapshot.to_dict())
 
     def get_revision(self, statblock_id: str, revision_id: str) -> StatblockRevisionResourceV1:
-        if not self._document(STATBLOCKS_COLLECTION, statblock_id).get().exists:
-            raise StatblockNotFoundError(statblock_id)
-        snapshot = self._revision_document(statblock_id, revision_id).get()
+        try:
+            if not self._document(STATBLOCKS_COLLECTION, statblock_id).get().exists:
+                raise StatblockNotFoundError(statblock_id)
+            snapshot = self._revision_document(statblock_id, revision_id).get()
+        except StatblockNotFoundError:
+            raise
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
         if not snapshot.exists:
             raise RevisionNotFoundError(revision_id)
         return StatblockRevisionResourceV1.model_validate(snapshot.to_dict())
 
     def list_for_statblock(self, statblock_id: str) -> list[StatblockRevisionResourceV1]:
-        if not self._document(STATBLOCKS_COLLECTION, statblock_id).get().exists:
-            raise StatblockNotFoundError(statblock_id)
+        try:
+            if not self._document(STATBLOCKS_COLLECTION, statblock_id).get().exists:
+                raise StatblockNotFoundError(statblock_id)
+            snapshots = list(
+                self._document(STATBLOCKS_COLLECTION, statblock_id).collection("revisions").stream()
+            )
+        except StatblockNotFoundError:
+            raise
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
         return [
             StatblockRevisionResourceV1.model_validate(snapshot.to_dict())
-            for snapshot in self._document(STATBLOCKS_COLLECTION, statblock_id).collection("revisions").stream()
+            for snapshot in snapshots
         ]
 
-    def get_idempotency(self, caller_scope: str, operation: str, idempotency_key: str) -> IdempotencyRecordV1 | None:
-        snapshot = self._idempotency_document(caller_scope, operation, idempotency_key).get()
-        return IdempotencyRecordV1.model_validate(snapshot.to_dict()) if snapshot.exists else None
+    def get_idempotency(
+        self, caller_scope: str, operation: str, idempotency_key: str
+    ) -> IdempotencyRecordV1 | None:
+        try:
+            snapshot = self._idempotency_document(caller_scope, operation, idempotency_key).get()
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
+        if not snapshot.exists:
+            return None
+        return IdempotencyRecordV1.model_validate(snapshot.to_dict())
 
-    def create_statblock(self, command: CreateStatblockCommand) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
-        canonical, digest, receipt = _persistence_material(command.definition)
-        now, statblock_id, revision_id = self._clock(), self._id_factory("sb"), self._id_factory("rev")
-        statblock = StatblockResourceV1(statblock_id=statblock_id, latest_revision_id=revision_id, created_at=now, created_by=command.created_by)
-        revision = StatblockRevisionResourceV1(
-            statblock_id=statblock_id, revision_id=revision_id, definition=command.definition,
-            canonical_definition=canonical, definition_digest=digest, validation_receipt=receipt,
-            provenance=_provenance(command.provenance, command.candidate_id),
-            asset_bindings=command.asset_bindings, created_at=now,
+    def create_statblock(
+        self, command: CreateStatblockCommand
+    ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
+        existing = self.get_idempotency(
+            command.caller_scope, "create_statblock", command.idempotency_key
         )
-        outcome = ResourceLocatorV1(resource_type="statblock", resource_id=statblock_id)
-        self._transactional_write(command.caller_scope, "create_statblock", command.idempotency_key, command.request_digest,
-                                  outcome, [(self._document(STATBLOCKS_COLLECTION, statblock_id), _dump(statblock)),
-                                            (self._revision_document(statblock_id, revision_id), _dump(revision))])
-        record = self.get_idempotency(command.caller_scope, "create_statblock", command.idempotency_key)
-        if record and record.outcome != outcome:
-            return self.get(record.outcome.resource_id), self.get_revision(record.outcome.resource_id, self.get(record.outcome.resource_id).latest_revision_id)
+        if existing is not None:
+            if existing.request_digest != command.request_digest:
+                raise IdempotencyConflictError(command.idempotency_key)
+            return (
+                self.get(existing.outcome.statblock_id),
+                self.get_revision(existing.outcome.statblock_id, existing.outcome.revision_id),
+            )
+
+        canonical, digest, receipt = _persistence_material(command.definition)
+        now = self._clock()
+        statblock_id = self._id_factory("sb")
+        revision_id = self._id_factory("rev")
+        definition = command.definition.model_copy(deep=True)
+        asset_bindings = deepcopy(command.asset_bindings)
+        provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
+        statblock = StatblockResourceV1(
+            statblock_id=statblock_id,
+            latest_revision_id=revision_id,
+            created_at=now,
+            created_by=command.created_by,
+        )
+        revision = StatblockRevisionResourceV1(
+            statblock_id=statblock_id,
+            revision_id=revision_id,
+            definition=definition,
+            canonical_definition=str(canonical),
+            definition_digest=digest,
+            validation_receipt=receipt,
+            provenance=provenance,
+            asset_bindings=asset_bindings,
+            created_at=now,
+        )
+        outcome = IdempotencyOutcomeV1(statblock_id=statblock_id, revision_id=revision_id)
+        self._transactional_write(
+            command.caller_scope,
+            "create_statblock",
+            command.idempotency_key,
+            command.request_digest,
+            outcome,
+            [
+                (self._document(STATBLOCKS_COLLECTION, statblock_id), _dump(statblock)),
+                (self._revision_document(statblock_id, revision_id), _dump(revision)),
+            ],
+        )
+        record = self.get_idempotency(
+            command.caller_scope, "create_statblock", command.idempotency_key
+        )
+        if record is not None and record.outcome != outcome:
+            return (
+                self.get(record.outcome.statblock_id),
+                self.get_revision(record.outcome.statblock_id, record.outcome.revision_id),
+            )
         return statblock, revision
 
     def append_revision(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1:
-        canonical, digest, receipt = _persistence_material(command.definition)
-        now, revision_id = self._clock(), self._id_factory("rev")
-        revision = StatblockRevisionResourceV1(
-            statblock_id=command.statblock_id, revision_id=revision_id, parent_revision_id=command.parent_revision_id,
-            definition=command.definition, canonical_definition=canonical, definition_digest=digest,
-            validation_receipt=receipt, provenance=_provenance(command.provenance, command.candidate_id),
-            asset_bindings=command.asset_bindings, created_at=now,
+        existing = self.get_idempotency(
+            command.caller_scope, "append_revision", command.idempotency_key
         )
-        statblock_ref = self._document(STATBLOCKS_COLLECTION, command.statblock_id)
-        self._transactional_append(command, statblock_ref, revision)
-        record = self.get_idempotency(command.caller_scope, "append_revision", command.idempotency_key)
-        if record and record.outcome.resource_id != revision_id:
-            return self.get_revision(command.statblock_id, record.outcome.resource_id)
+        if existing is not None:
+            if existing.request_digest != command.request_digest:
+                raise IdempotencyConflictError(command.idempotency_key)
+            return self.get_revision(existing.outcome.statblock_id, existing.outcome.revision_id)
+
+        canonical, digest, receipt = _persistence_material(command.definition)
+        now = self._clock()
+        revision_id = self._id_factory("rev")
+        definition = command.definition.model_copy(deep=True)
+        asset_bindings = deepcopy(command.asset_bindings)
+        provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
+        revision = StatblockRevisionResourceV1(
+            statblock_id=command.statblock_id,
+            revision_id=revision_id,
+            parent_revision_id=command.parent_revision_id,
+            definition=definition,
+            canonical_definition=str(canonical),
+            definition_digest=digest,
+            validation_receipt=receipt,
+            provenance=provenance,
+            asset_bindings=asset_bindings,
+            created_at=now,
+        )
+        self._transactional_append(command, revision)
+        record = self.get_idempotency(
+            command.caller_scope, "append_revision", command.idempotency_key
+        )
+        if record is not None and record.outcome.revision_id != revision_id:
+            return self.get_revision(record.outcome.statblock_id, record.outcome.revision_id)
         return revision
 
-    def _transactional_write(self, scope: str, operation: str, key: str, digest: str, outcome: ResourceLocatorV1, writes: list[tuple[Any, dict]]) -> None:
+    def _transactional_write(
+        self,
+        scope: str,
+        operation: str,
+        key: str,
+        digest: str,
+        outcome: IdempotencyOutcomeV1,
+        writes: list[tuple[Any, dict]],
+    ) -> None:
         from google.cloud.firestore_v1 import transactional
+
         idem_ref = self._idempotency_document(scope, operation, key)
+
         @transactional
         def operation_fn(transaction):
             existing = idem_ref.get(transaction=transaction)
@@ -139,17 +257,34 @@ class FirestoreStatblockPersistenceRepository:
                 return
             for document, data in writes:
                 transaction.create(document, data)
-            transaction.create(idem_ref, _dump(IdempotencyRecordV1(
-                caller_scope=scope, operation=operation, idempotency_key=key, request_digest=digest,
-                outcome=outcome, created_at=self._clock(),
-            )))
+            transaction.create(
+                idem_ref,
+                _dump(
+                    IdempotencyRecordV1(
+                        caller_scope=scope,
+                        operation=operation,
+                        idempotency_key=key,
+                        request_digest=digest,
+                        outcome=outcome,
+                        created_at=self._clock(),
+                    )
+                ),
+            )
+
         self._run_transaction(operation_fn)
 
-    def _transactional_append(self, command: AppendRevisionCommand, statblock_ref: Any, revision: StatblockRevisionResourceV1) -> None:
+    def _transactional_append(
+        self, command: AppendRevisionCommand, revision: StatblockRevisionResourceV1
+    ) -> None:
         from google.cloud.firestore_v1 import transactional
-        idem_ref = self._idempotency_document(command.caller_scope, "append_revision", command.idempotency_key)
+
+        idem_ref = self._idempotency_document(
+            command.caller_scope, "append_revision", command.idempotency_key
+        )
+        statblock_ref = self._document(STATBLOCKS_COLLECTION, command.statblock_id)
         parent_ref = self._revision_document(command.statblock_id, command.parent_revision_id)
         revision_ref = self._revision_document(command.statblock_id, revision.revision_id)
+
         @transactional
         def operation_fn(transaction):
             existing = idem_ref.get(transaction=transaction)
@@ -158,36 +293,115 @@ class FirestoreStatblockPersistenceRepository:
                 if record.request_digest != command.request_digest:
                     raise IdempotencyConflictError(command.idempotency_key)
                 return
-            if not statblock_ref.get(transaction=transaction).exists or not parent_ref.get(transaction=transaction).exists:
-                raise ParentRevisionMismatchError(command.statblock_id, command.parent_revision_id)
+
+            statblock_snap = statblock_ref.get(transaction=transaction)
+            if not statblock_snap.exists:
+                raise StatblockNotFoundError(command.statblock_id)
+            statblock = StatblockResourceV1.model_validate(statblock_snap.to_dict())
+
+            parent_snap = parent_ref.get(transaction=transaction)
+            if not parent_snap.exists:
+                raise ParentRevisionMismatchError(
+                    command.statblock_id, command.parent_revision_id
+                )
+            if statblock.latest_revision_id != command.parent_revision_id:
+                raise StaleParentRevisionError(
+                    command.statblock_id,
+                    command.parent_revision_id,
+                    statblock.latest_revision_id,
+                )
+
             transaction.create(revision_ref, _dump(revision))
             transaction.update(statblock_ref, {"latest_revision_id": revision.revision_id})
-            transaction.create(idem_ref, _dump(IdempotencyRecordV1(
-                caller_scope=command.caller_scope, operation="append_revision", idempotency_key=command.idempotency_key,
-                request_digest=command.request_digest, outcome=ResourceLocatorV1(resource_type="revision", resource_id=revision.revision_id),
-                created_at=self._clock(),
-            )))
+            transaction.create(
+                idem_ref,
+                _dump(
+                    IdempotencyRecordV1(
+                        caller_scope=command.caller_scope,
+                        operation="append_revision",
+                        idempotency_key=command.idempotency_key,
+                        request_digest=command.request_digest,
+                        outcome=IdempotencyOutcomeV1(
+                            statblock_id=command.statblock_id,
+                            revision_id=revision.revision_id,
+                        ),
+                        created_at=self._clock(),
+                    )
+                ),
+            )
+
         self._run_transaction(operation_fn)
 
     def _run_transaction(self, operation: Any) -> None:
+        known = (
+            IdempotencyConflictError,
+            ParentRevisionMismatchError,
+            StaleParentRevisionError,
+            StatblockNotFoundError,
+            ImmutableRevisionConflictError,
+            ImmutableResourceConflictError,
+        )
         try:
             operation(self._client.transaction())
-        except (IdempotencyConflictError, ParentRevisionMismatchError):
+        except known:
             raise
         except Exception as error:
+            if _is_already_exists(error):
+                raise ImmutableRevisionConflictError("unknown") from error
+            if _is_unavailable(error):
+                raise PersistenceUnavailableError() from error
             raise TransactionIndeterminateError() from error
 
     def _document(self, collection: str, document_id: str) -> Any:
         return self._client.collection(collection).document(document_id)
 
     def _revision_document(self, statblock_id: str, revision_id: str) -> Any:
-        return self._document(STATBLOCKS_COLLECTION, statblock_id).collection("revisions").document(revision_id)
+        return self._document(STATBLOCKS_COLLECTION, statblock_id).collection("revisions").document(
+            revision_id
+        )
 
     def _idempotency_document(self, scope: str, operation: str, key: str) -> Any:
         import hashlib
+
         digest = hashlib.sha256(f"{scope}\x1f{operation}\x1f{key}".encode()).hexdigest()
         return self._document(IDEMPOTENCY_COLLECTION, digest)
 
 
 def _dump(model: Any) -> dict[str, Any]:
-    return model.model_dump(mode="json")
+    """Encode models for Firestore while preserving native timestamp fields.
+
+    ``model_dump(mode="json")`` stringifies datetimes and breaks TTL policies that
+    require a timestamp on ``expires_at``. Canonical definition text remains an
+    exact string.
+    """
+
+    return _firestore_encode(model.model_dump(mode="python"))
+
+
+def _firestore_encode(value: Any) -> Any:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _firestore_encode(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_firestore_encode(item) for item in value]
+    return value
+
+
+def _is_already_exists(error: Exception) -> bool:
+    name = type(error).__name__
+    if name in {"AlreadyExists", "Conflict"}:
+        return True
+    return "already exists" in str(error).lower()
+
+
+def _is_unavailable(error: Exception) -> bool:
+    name = type(error).__name__
+    if name in {"ServiceUnavailable", "DeadlineExceeded", "Unavailable", "RetryError"}:
+        return True
+    message = str(error).lower()
+    return "unavailable" in message or "deadline" in message

--- a/statblocks_v1/infrastructure/firestore_repositories.py
+++ b/statblocks_v1/infrastructure/firestore_repositories.py
@@ -178,17 +178,30 @@ class FirestoreStatblockPersistenceRepository:
             created_at=now,
         )
         outcome = IdempotencyOutcomeV1(statblock_id=statblock_id, revision_id=revision_id)
-        self._transactional_write(
-            command.caller_scope,
-            "create_statblock",
-            command.idempotency_key,
-            command.request_digest,
-            outcome,
-            [
-                (self._document(STATBLOCKS_COLLECTION, statblock_id), _dump(statblock)),
-                (self._revision_document(statblock_id, revision_id), _dump(revision)),
-            ],
-        )
+        try:
+            self._transactional_write(
+                command.caller_scope,
+                "create_statblock",
+                command.idempotency_key,
+                command.request_digest,
+                outcome,
+                [
+                    (self._document(STATBLOCKS_COLLECTION, statblock_id), _dump(statblock)),
+                    (self._revision_document(statblock_id, revision_id), _dump(revision)),
+                ],
+                already_exists=ImmutableResourceConflictError("statblock", statblock_id),
+            )
+        except TransactionIndeterminateError:
+            reconciled = self._reconcile_idempotent_outcome(
+                command.caller_scope,
+                "create_statblock",
+                command.idempotency_key,
+                command.request_digest,
+            )
+            return (
+                self.get(reconciled.statblock_id),
+                self.get_revision(reconciled.statblock_id, reconciled.revision_id),
+            )
         record = self.get_idempotency(
             command.caller_scope, "create_statblock", command.idempotency_key
         )
@@ -226,7 +239,16 @@ class FirestoreStatblockPersistenceRepository:
             asset_bindings=asset_bindings,
             created_at=now,
         )
-        self._transactional_append(command, revision)
+        try:
+            self._transactional_append(command, revision)
+        except TransactionIndeterminateError:
+            reconciled = self._reconcile_idempotent_outcome(
+                command.caller_scope,
+                "append_revision",
+                command.idempotency_key,
+                command.request_digest,
+            )
+            return self.get_revision(reconciled.statblock_id, reconciled.revision_id)
         record = self.get_idempotency(
             command.caller_scope, "append_revision", command.idempotency_key
         )
@@ -242,6 +264,8 @@ class FirestoreStatblockPersistenceRepository:
         digest: str,
         outcome: IdempotencyOutcomeV1,
         writes: list[tuple[Any, dict]],
+        *,
+        already_exists: Exception,
     ) -> None:
         from google.cloud.firestore_v1 import transactional
 
@@ -271,7 +295,7 @@ class FirestoreStatblockPersistenceRepository:
                 ),
             )
 
-        self._run_transaction(operation_fn)
+        self._run_transaction(operation_fn, already_exists=already_exists)
 
     def _transactional_append(
         self, command: AppendRevisionCommand, revision: StatblockRevisionResourceV1
@@ -330,9 +354,29 @@ class FirestoreStatblockPersistenceRepository:
                 ),
             )
 
-        self._run_transaction(operation_fn)
+        self._run_transaction(
+            operation_fn,
+            already_exists=ImmutableRevisionConflictError(revision.revision_id),
+        )
 
-    def _run_transaction(self, operation: Any) -> None:
+    def _reconcile_idempotent_outcome(
+        self, scope: str, operation: str, key: str, digest: str
+    ) -> IdempotencyOutcomeV1:
+        """Resolve an uncertain commit via the durable idempotency record."""
+
+        try:
+            record = self.get_idempotency(scope, operation, key)
+        except PersistenceUnavailableError as error:
+            raise TransactionIndeterminateError() from error
+        if record is None:
+            raise TransactionIndeterminateError()
+        if record.request_digest != digest:
+            raise IdempotencyConflictError(key)
+        return record.outcome
+
+    def _run_transaction(
+        self, operation: Any, *, already_exists: Exception
+    ) -> None:
         known = (
             IdempotencyConflictError,
             ParentRevisionMismatchError,
@@ -347,9 +391,9 @@ class FirestoreStatblockPersistenceRepository:
             raise
         except Exception as error:
             if _is_already_exists(error):
-                raise ImmutableRevisionConflictError("unknown") from error
-            if _is_unavailable(error):
-                raise PersistenceUnavailableError() from error
+                raise already_exists from error
+            # Deadline/transport/retry failures may arrive after commit. Treat every
+            # non-domain transaction failure as indeterminate so callers reconcile.
             raise TransactionIndeterminateError() from error
 
     def _document(self, collection: str, document_id: str) -> Any:
@@ -397,11 +441,3 @@ def _is_already_exists(error: Exception) -> bool:
     if name in {"AlreadyExists", "Conflict"}:
         return True
     return "already exists" in str(error).lower()
-
-
-def _is_unavailable(error: Exception) -> bool:
-    name = type(error).__name__
-    if name in {"ServiceUnavailable", "DeadlineExceeded", "Unavailable", "RetryError"}:
-        return True
-    message = str(error).lower()
-    return "unavailable" in message or "deadline" in message

--- a/statblocks_v1/infrastructure/firestore_repositories.py
+++ b/statblocks_v1/infrastructure/firestore_repositories.py
@@ -1,0 +1,193 @@
+"""Synchronous Firestore adapters for immutable statblock v1 persistence.
+
+Callers in async code must use ``await asyncio.to_thread(repository.method, ...)``.
+The adapter deliberately does not expose async-looking methods that could block
+the event loop.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+from uuid import uuid4
+
+from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
+from statblocks_v1.domain.errors import (
+    CandidateExpiredError, CandidateNotFoundError, IdempotencyConflictError,
+    ParentRevisionMismatchError, PersistenceUnavailableError, RevisionNotFoundError,
+    StatblockNotFoundError, TransactionIndeterminateError,
+)
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1, IdempotencyRecordV1, ResourceLocatorV1,
+    StatblockResourceV1, StatblockRevisionResourceV1,
+)
+from statblocks_v1.infrastructure.memory_repositories import (
+    _persistence_material, _provenance, utc_now,
+)
+
+CANDIDATES_COLLECTION = "dungeonbuddy_statblock_candidates_v1"
+STATBLOCKS_COLLECTION = "dungeonbuddy_statblocks_v1"
+IDEMPOTENCY_COLLECTION = "dungeonbuddy_statblock_idempotency_v1"
+
+
+class FirestoreCandidateRepository:
+    """Candidate documents are mutable only for Firestore TTL deletion."""
+
+    def __init__(self, client: Any, *, clock: Callable[[], datetime] = utc_now) -> None:
+        self._client, self._clock = client, clock
+
+    def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1:
+        try:
+            self._client.collection(CANDIDATES_COLLECTION).document(candidate.candidate_id).create(_dump(candidate))
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
+        return candidate.model_copy(deep=True)
+
+    def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1:
+        try:
+            snapshot = self._client.collection(CANDIDATES_COLLECTION).document(candidate_id).get()
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
+        if not snapshot.exists:
+            raise CandidateNotFoundError(candidate_id)
+        candidate = GeneratedStatblockCandidateV1.model_validate(snapshot.to_dict())
+        if candidate.expires_at <= (now or self._clock()):
+            raise CandidateExpiredError(candidate_id)
+        return candidate
+
+
+class FirestoreStatblockPersistenceRepository:
+    """Atomic create/append adapter using Firestore read-write transactions."""
+
+    def __init__(
+        self, client: Any, *, clock: Callable[[], datetime] = utc_now,
+        id_factory: Callable[[str], str] | None = None,
+    ) -> None:
+        self._client, self._clock = client, clock
+        self._id_factory = id_factory or (lambda prefix: f"{prefix}_{uuid4().hex}")
+
+    def get(self, statblock_id: str) -> StatblockResourceV1:
+        snapshot = self._document(STATBLOCKS_COLLECTION, statblock_id).get()
+        if not snapshot.exists:
+            raise StatblockNotFoundError(statblock_id)
+        return StatblockResourceV1.model_validate(snapshot.to_dict())
+
+    def get_revision(self, statblock_id: str, revision_id: str) -> StatblockRevisionResourceV1:
+        if not self._document(STATBLOCKS_COLLECTION, statblock_id).get().exists:
+            raise StatblockNotFoundError(statblock_id)
+        snapshot = self._revision_document(statblock_id, revision_id).get()
+        if not snapshot.exists:
+            raise RevisionNotFoundError(revision_id)
+        return StatblockRevisionResourceV1.model_validate(snapshot.to_dict())
+
+    def list_for_statblock(self, statblock_id: str) -> list[StatblockRevisionResourceV1]:
+        if not self._document(STATBLOCKS_COLLECTION, statblock_id).get().exists:
+            raise StatblockNotFoundError(statblock_id)
+        return [
+            StatblockRevisionResourceV1.model_validate(snapshot.to_dict())
+            for snapshot in self._document(STATBLOCKS_COLLECTION, statblock_id).collection("revisions").stream()
+        ]
+
+    def get_idempotency(self, caller_scope: str, operation: str, idempotency_key: str) -> IdempotencyRecordV1 | None:
+        snapshot = self._idempotency_document(caller_scope, operation, idempotency_key).get()
+        return IdempotencyRecordV1.model_validate(snapshot.to_dict()) if snapshot.exists else None
+
+    def create_statblock(self, command: CreateStatblockCommand) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
+        canonical, digest, receipt = _persistence_material(command.definition)
+        now, statblock_id, revision_id = self._clock(), self._id_factory("sb"), self._id_factory("rev")
+        statblock = StatblockResourceV1(statblock_id=statblock_id, latest_revision_id=revision_id, created_at=now, created_by=command.created_by)
+        revision = StatblockRevisionResourceV1(
+            statblock_id=statblock_id, revision_id=revision_id, definition=command.definition,
+            canonical_definition=canonical, definition_digest=digest, validation_receipt=receipt,
+            provenance=_provenance(command.provenance, command.candidate_id),
+            asset_bindings=command.asset_bindings, created_at=now,
+        )
+        outcome = ResourceLocatorV1(resource_type="statblock", resource_id=statblock_id)
+        self._transactional_write(command.caller_scope, "create_statblock", command.idempotency_key, command.request_digest,
+                                  outcome, [(self._document(STATBLOCKS_COLLECTION, statblock_id), _dump(statblock)),
+                                            (self._revision_document(statblock_id, revision_id), _dump(revision))])
+        record = self.get_idempotency(command.caller_scope, "create_statblock", command.idempotency_key)
+        if record and record.outcome != outcome:
+            return self.get(record.outcome.resource_id), self.get_revision(record.outcome.resource_id, self.get(record.outcome.resource_id).latest_revision_id)
+        return statblock, revision
+
+    def append_revision(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1:
+        canonical, digest, receipt = _persistence_material(command.definition)
+        now, revision_id = self._clock(), self._id_factory("rev")
+        revision = StatblockRevisionResourceV1(
+            statblock_id=command.statblock_id, revision_id=revision_id, parent_revision_id=command.parent_revision_id,
+            definition=command.definition, canonical_definition=canonical, definition_digest=digest,
+            validation_receipt=receipt, provenance=_provenance(command.provenance, command.candidate_id),
+            asset_bindings=command.asset_bindings, created_at=now,
+        )
+        statblock_ref = self._document(STATBLOCKS_COLLECTION, command.statblock_id)
+        self._transactional_append(command, statblock_ref, revision)
+        record = self.get_idempotency(command.caller_scope, "append_revision", command.idempotency_key)
+        if record and record.outcome.resource_id != revision_id:
+            return self.get_revision(command.statblock_id, record.outcome.resource_id)
+        return revision
+
+    def _transactional_write(self, scope: str, operation: str, key: str, digest: str, outcome: ResourceLocatorV1, writes: list[tuple[Any, dict]]) -> None:
+        from google.cloud.firestore_v1 import transactional
+        idem_ref = self._idempotency_document(scope, operation, key)
+        @transactional
+        def operation_fn(transaction):
+            existing = idem_ref.get(transaction=transaction)
+            if existing.exists:
+                record = IdempotencyRecordV1.model_validate(existing.to_dict())
+                if record.request_digest != digest:
+                    raise IdempotencyConflictError(key)
+                return
+            for document, data in writes:
+                transaction.create(document, data)
+            transaction.create(idem_ref, _dump(IdempotencyRecordV1(
+                caller_scope=scope, operation=operation, idempotency_key=key, request_digest=digest,
+                outcome=outcome, created_at=self._clock(),
+            )))
+        self._run_transaction(operation_fn)
+
+    def _transactional_append(self, command: AppendRevisionCommand, statblock_ref: Any, revision: StatblockRevisionResourceV1) -> None:
+        from google.cloud.firestore_v1 import transactional
+        idem_ref = self._idempotency_document(command.caller_scope, "append_revision", command.idempotency_key)
+        parent_ref = self._revision_document(command.statblock_id, command.parent_revision_id)
+        revision_ref = self._revision_document(command.statblock_id, revision.revision_id)
+        @transactional
+        def operation_fn(transaction):
+            existing = idem_ref.get(transaction=transaction)
+            if existing.exists:
+                record = IdempotencyRecordV1.model_validate(existing.to_dict())
+                if record.request_digest != command.request_digest:
+                    raise IdempotencyConflictError(command.idempotency_key)
+                return
+            if not statblock_ref.get(transaction=transaction).exists or not parent_ref.get(transaction=transaction).exists:
+                raise ParentRevisionMismatchError(command.statblock_id, command.parent_revision_id)
+            transaction.create(revision_ref, _dump(revision))
+            transaction.update(statblock_ref, {"latest_revision_id": revision.revision_id})
+            transaction.create(idem_ref, _dump(IdempotencyRecordV1(
+                caller_scope=command.caller_scope, operation="append_revision", idempotency_key=command.idempotency_key,
+                request_digest=command.request_digest, outcome=ResourceLocatorV1(resource_type="revision", resource_id=revision.revision_id),
+                created_at=self._clock(),
+            )))
+        self._run_transaction(operation_fn)
+
+    def _run_transaction(self, operation: Any) -> None:
+        try:
+            operation(self._client.transaction())
+        except (IdempotencyConflictError, ParentRevisionMismatchError):
+            raise
+        except Exception as error:
+            raise TransactionIndeterminateError() from error
+
+    def _document(self, collection: str, document_id: str) -> Any:
+        return self._client.collection(collection).document(document_id)
+
+    def _revision_document(self, statblock_id: str, revision_id: str) -> Any:
+        return self._document(STATBLOCKS_COLLECTION, statblock_id).collection("revisions").document(revision_id)
+
+    def _idempotency_document(self, scope: str, operation: str, key: str) -> Any:
+        import hashlib
+        digest = hashlib.sha256(f"{scope}\x1f{operation}\x1f{key}".encode()).hexdigest()
+        return self._document(IDEMPOTENCY_COLLECTION, digest)
+
+
+def _dump(model: Any) -> dict[str, Any]:
+    return model.model_dump(mode="json")

--- a/statblocks_v1/infrastructure/memory_repositories.py
+++ b/statblocks_v1/infrastructure/memory_repositories.py
@@ -94,43 +94,52 @@ class InMemoryStatblockPersistenceRepository:
         self._idempotency: dict[tuple[str, str, str], IdempotencyRecordV1] = {}
 
     def get(self, statblock_id: str) -> StatblockResourceV1:
-        statblock = self._statblocks.get(statblock_id)
-        if statblock is None:
-            raise StatblockNotFoundError(statblock_id)
-        return _copy(statblock)
+        with self._lock:
+            statblock = self._statblocks.get(statblock_id)
+            if statblock is None:
+                raise StatblockNotFoundError(statblock_id)
+            return _copy(statblock)
 
     def get_idempotency(
         self, caller_scope: str, operation: str, idempotency_key: str
     ) -> IdempotencyRecordV1 | None:
-        record = self._idempotency.get((caller_scope, operation, idempotency_key))
-        return _copy(record) if record else None
+        with self._lock:
+            record = self._idempotency.get((caller_scope, operation, idempotency_key))
+            return _copy(record) if record else None
 
     def get_revision(self, statblock_id: str, revision_id: str) -> StatblockRevisionResourceV1:
-        if statblock_id not in self._statblocks:
-            raise StatblockNotFoundError(statblock_id)
-        revision = self._revisions.get((statblock_id, revision_id))
-        if revision is None:
-            raise RevisionNotFoundError(revision_id)
-        return _copy(revision)
+        with self._lock:
+            if statblock_id not in self._statblocks:
+                raise StatblockNotFoundError(statblock_id)
+            revision = self._revisions.get((statblock_id, revision_id))
+            if revision is None:
+                raise RevisionNotFoundError(revision_id)
+            return _copy(revision)
 
     def list_for_statblock(self, statblock_id: str) -> list[StatblockRevisionResourceV1]:
-        if statblock_id not in self._statblocks:
-            raise StatblockNotFoundError(statblock_id)
-        return [
-            _copy(revision)
-            for (owner, _), revision in self._revisions.items()
-            if owner == statblock_id
-        ]
+        with self._lock:
+            if statblock_id not in self._statblocks:
+                raise StatblockNotFoundError(statblock_id)
+            return [
+                _copy(revision)
+                for (owner, _), revision in tuple(self._revisions.items())
+                if owner == statblock_id
+            ]
 
     def create_statblock(
         self, command: CreateStatblockCommand
     ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
+        # Snapshot once at the repository boundary; command fields are already frozen.
+        request_digest = command.request_digest
+        definition = command.definition
+        provenance = command.provenance
+        asset_bindings = command.asset_bindings
         with self._lock:
             replay = self._replay(
                 command.caller_scope,
                 "create_statblock",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
             )
             if replay is not None:
                 return (
@@ -138,7 +147,7 @@ class InMemoryStatblockPersistenceRepository:
                     self.get_revision(replay.statblock_id, replay.revision_id),
                 )
 
-            canonical, digest, receipt = _persistence_material(command.definition)
+            canonical, digest, receipt = _persistence_material(definition)
             now = self._clock()
             statblock_id = self._id_factory("sb")
             revision_id = self._id_factory("rev")
@@ -147,9 +156,9 @@ class InMemoryStatblockPersistenceRepository:
             if (statblock_id, revision_id) in self._revisions:
                 raise ImmutableRevisionConflictError(revision_id)
 
-            definition = command.definition.model_copy(deep=True)
-            asset_bindings = deepcopy(command.asset_bindings)
-            provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
+            stored_definition = definition.model_copy(deep=True)
+            stored_bindings = deepcopy(asset_bindings)
+            stored_provenance = deepcopy(_provenance(provenance, command.candidate_id))
             statblock = StatblockResourceV1(
                 statblock_id=statblock_id,
                 latest_revision_id=revision_id,
@@ -159,12 +168,12 @@ class InMemoryStatblockPersistenceRepository:
             revision = StatblockRevisionResourceV1(
                 statblock_id=statblock_id,
                 revision_id=revision_id,
-                definition=definition,
+                definition=stored_definition,
                 canonical_definition=str(canonical),
                 definition_digest=digest,
                 validation_receipt=receipt,
-                provenance=provenance,
-                asset_bindings=asset_bindings,
+                provenance=stored_provenance,
+                asset_bindings=stored_bindings,
                 created_at=now,
             )
             self._statblocks[statblock_id] = statblock
@@ -173,19 +182,23 @@ class InMemoryStatblockPersistenceRepository:
                 command.caller_scope,
                 "create_statblock",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
                 IdempotencyOutcomeV1(statblock_id=statblock_id, revision_id=revision_id),
                 now,
             )
             return _copy(statblock), _copy(revision)
 
     def append_revision(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1:
+        request_digest = command.request_digest
+        definition = command.definition
+        provenance = command.provenance
+        asset_bindings = command.asset_bindings
         with self._lock:
             replay = self._replay(
                 command.caller_scope,
                 "append_revision",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
             )
             if replay is not None:
                 return self.get_revision(replay.statblock_id, replay.revision_id)
@@ -204,25 +217,25 @@ class InMemoryStatblockPersistenceRepository:
                     statblock.latest_revision_id,
                 )
 
-            canonical, digest, receipt = _persistence_material(command.definition)
+            canonical, digest, receipt = _persistence_material(definition)
             now = self._clock()
             revision_id = self._id_factory("rev")
             if (command.statblock_id, revision_id) in self._revisions:
                 raise ImmutableRevisionConflictError(revision_id)
 
-            definition = command.definition.model_copy(deep=True)
-            asset_bindings = deepcopy(command.asset_bindings)
-            provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
+            stored_definition = definition.model_copy(deep=True)
+            stored_bindings = deepcopy(asset_bindings)
+            stored_provenance = deepcopy(_provenance(provenance, command.candidate_id))
             revision = StatblockRevisionResourceV1(
                 statblock_id=command.statblock_id,
                 revision_id=revision_id,
                 parent_revision_id=command.parent_revision_id,
-                definition=definition,
+                definition=stored_definition,
                 canonical_definition=str(canonical),
                 definition_digest=digest,
                 validation_receipt=receipt,
-                provenance=provenance,
-                asset_bindings=asset_bindings,
+                provenance=stored_provenance,
+                asset_bindings=stored_bindings,
                 created_at=now,
             )
             self._revisions[(command.statblock_id, revision_id)] = revision
@@ -233,7 +246,7 @@ class InMemoryStatblockPersistenceRepository:
                 command.caller_scope,
                 "append_revision",
                 command.idempotency_key,
-                command.request_digest,
+                request_digest,
                 IdempotencyOutcomeV1(
                     statblock_id=command.statblock_id, revision_id=revision_id
                 ),

--- a/statblocks_v1/infrastructure/memory_repositories.py
+++ b/statblocks_v1/infrastructure/memory_repositories.py
@@ -56,22 +56,25 @@ class DeterministicIdFactory:
 class InMemoryCandidateRepository:
     def __init__(self, *, clock: Clock = utc_now) -> None:
         self._clock = clock
+        self._lock = RLock()
         self._candidates: dict[str, GeneratedStatblockCandidateV1] = {}
 
     def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1:
-        if candidate.candidate_id in self._candidates:
-            raise ImmutableResourceConflictError("candidate", candidate.candidate_id)
-        stored = _copy(candidate)
-        self._candidates[candidate.candidate_id] = stored
-        return _copy(stored)
+        with self._lock:
+            if candidate.candidate_id in self._candidates:
+                raise ImmutableResourceConflictError("candidate", candidate.candidate_id)
+            stored = _copy(candidate)
+            self._candidates[candidate.candidate_id] = stored
+            return _copy(stored)
 
     def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1:
-        candidate = self._candidates.get(candidate_id)
-        if candidate is None:
-            raise CandidateNotFoundError(candidate_id)
-        if candidate.expires_at <= (now or self._clock()):
-            raise CandidateExpiredError(candidate_id)
-        return _copy(candidate)
+        with self._lock:
+            candidate = self._candidates.get(candidate_id)
+            if candidate is None:
+                raise CandidateNotFoundError(candidate_id)
+            if candidate.expires_at <= (now or self._clock()):
+                raise CandidateExpiredError(candidate_id)
+            return _copy(candidate)
 
 
 class InMemoryStatblockPersistenceRepository:

--- a/statblocks_v1/infrastructure/memory_repositories.py
+++ b/statblocks_v1/infrastructure/memory_repositories.py
@@ -1,6 +1,7 @@
 """Deterministic, thread-safe in-memory repositories for statblock v1 tests."""
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime, timezone
 from threading import RLock
 from typing import Callable
@@ -15,18 +16,23 @@ from statblocks_v1.domain.errors import (
     CandidateExpiredError,
     CandidateNotFoundError,
     IdempotencyConflictError,
+    ImmutableResourceConflictError,
+    ImmutableRevisionConflictError,
     ParentRevisionMismatchError,
+    PersistenceValidationError,
     RevisionNotFoundError,
+    StaleParentRevisionError,
     StatblockNotFoundError,
 )
 from statblocks_v1.domain.receipts import ValidationMode
 from statblocks_v1.domain.resources import (
     GeneratedStatblockCandidateV1,
+    IdempotencyOutcomeV1,
     IdempotencyRecordV1,
-    ResourceLocatorV1,
     StatblockResourceV1,
     StatblockRevisionResourceV1,
 )
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
 
 Clock = Callable[[], datetime]
@@ -53,8 +59,11 @@ class InMemoryCandidateRepository:
         self._candidates: dict[str, GeneratedStatblockCandidateV1] = {}
 
     def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1:
-        self._candidates[candidate.candidate_id] = _copy(candidate)
-        return _copy(candidate)
+        if candidate.candidate_id in self._candidates:
+            raise ImmutableResourceConflictError("candidate", candidate.candidate_id)
+        stored = _copy(candidate)
+        self._candidates[candidate.candidate_id] = stored
+        return _copy(stored)
 
     def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1:
         candidate = self._candidates.get(candidate_id)
@@ -114,52 +123,124 @@ class InMemoryStatblockPersistenceRepository:
         self, command: CreateStatblockCommand
     ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
         with self._lock:
-            replay = self._replay(command.caller_scope, "create_statblock", command.idempotency_key, command.request_digest)
-            if replay:
-                statblock = self.get(replay.resource_id)
-                return statblock, self.get_revision(statblock.statblock_id, statblock.latest_revision_id)
+            replay = self._replay(
+                command.caller_scope,
+                "create_statblock",
+                command.idempotency_key,
+                command.request_digest,
+            )
+            if replay is not None:
+                return (
+                    self.get(replay.statblock_id),
+                    self.get_revision(replay.statblock_id, replay.revision_id),
+                )
+
             canonical, digest, receipt = _persistence_material(command.definition)
             now = self._clock()
-            statblock_id, revision_id = self._id_factory("sb"), self._id_factory("rev")
+            statblock_id = self._id_factory("sb")
+            revision_id = self._id_factory("rev")
+            if statblock_id in self._statblocks:
+                raise ImmutableResourceConflictError("statblock", statblock_id)
+            if (statblock_id, revision_id) in self._revisions:
+                raise ImmutableRevisionConflictError(revision_id)
+
+            definition = command.definition.model_copy(deep=True)
+            asset_bindings = deepcopy(command.asset_bindings)
+            provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
             statblock = StatblockResourceV1(
-                statblock_id=statblock_id, latest_revision_id=revision_id, created_at=now, created_by=command.created_by
+                statblock_id=statblock_id,
+                latest_revision_id=revision_id,
+                created_at=now,
+                created_by=command.created_by,
             )
             revision = StatblockRevisionResourceV1(
-                statblock_id=statblock_id, revision_id=revision_id, definition=command.definition,
-                canonical_definition=canonical, definition_digest=digest, validation_receipt=receipt,
-                provenance=_provenance(command.provenance, command.candidate_id),
-                asset_bindings=command.asset_bindings, created_at=now,
+                statblock_id=statblock_id,
+                revision_id=revision_id,
+                definition=definition,
+                canonical_definition=str(canonical),
+                definition_digest=digest,
+                validation_receipt=receipt,
+                provenance=provenance,
+                asset_bindings=asset_bindings,
+                created_at=now,
             )
-            self._statblocks[statblock_id], self._revisions[(statblock_id, revision_id)] = statblock, revision
-            self._record(command.caller_scope, "create_statblock", command.idempotency_key, command.request_digest,
-                         ResourceLocatorV1(resource_type="statblock", resource_id=statblock_id), now)
+            self._statblocks[statblock_id] = statblock
+            self._revisions[(statblock_id, revision_id)] = revision
+            self._record(
+                command.caller_scope,
+                "create_statblock",
+                command.idempotency_key,
+                command.request_digest,
+                IdempotencyOutcomeV1(statblock_id=statblock_id, revision_id=revision_id),
+                now,
+            )
             return _copy(statblock), _copy(revision)
 
     def append_revision(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1:
         with self._lock:
-            replay = self._replay(command.caller_scope, "append_revision", command.idempotency_key, command.request_digest)
-            if replay:
-                return self.get_revision(command.statblock_id, replay.resource_id)
+            replay = self._replay(
+                command.caller_scope,
+                "append_revision",
+                command.idempotency_key,
+                command.request_digest,
+            )
+            if replay is not None:
+                return self.get_revision(replay.statblock_id, replay.revision_id)
+
             statblock = self._statblocks.get(command.statblock_id)
             if statblock is None:
                 raise StatblockNotFoundError(command.statblock_id)
             if (command.statblock_id, command.parent_revision_id) not in self._revisions:
-                raise ParentRevisionMismatchError(command.statblock_id, command.parent_revision_id)
+                raise ParentRevisionMismatchError(
+                    command.statblock_id, command.parent_revision_id
+                )
+            if statblock.latest_revision_id != command.parent_revision_id:
+                raise StaleParentRevisionError(
+                    command.statblock_id,
+                    command.parent_revision_id,
+                    statblock.latest_revision_id,
+                )
+
             canonical, digest, receipt = _persistence_material(command.definition)
-            now, revision_id = self._clock(), self._id_factory("rev")
+            now = self._clock()
+            revision_id = self._id_factory("rev")
+            if (command.statblock_id, revision_id) in self._revisions:
+                raise ImmutableRevisionConflictError(revision_id)
+
+            definition = command.definition.model_copy(deep=True)
+            asset_bindings = deepcopy(command.asset_bindings)
+            provenance = deepcopy(_provenance(command.provenance, command.candidate_id))
             revision = StatblockRevisionResourceV1(
-                statblock_id=command.statblock_id, revision_id=revision_id, parent_revision_id=command.parent_revision_id,
-                definition=command.definition, canonical_definition=canonical, definition_digest=digest,
-                validation_receipt=receipt, provenance=_provenance(command.provenance, command.candidate_id),
-                asset_bindings=command.asset_bindings, created_at=now,
+                statblock_id=command.statblock_id,
+                revision_id=revision_id,
+                parent_revision_id=command.parent_revision_id,
+                definition=definition,
+                canonical_definition=str(canonical),
+                definition_digest=digest,
+                validation_receipt=receipt,
+                provenance=provenance,
+                asset_bindings=asset_bindings,
+                created_at=now,
             )
             self._revisions[(command.statblock_id, revision_id)] = revision
-            self._statblocks[command.statblock_id] = statblock.model_copy(update={"latest_revision_id": revision_id})
-            self._record(command.caller_scope, "append_revision", command.idempotency_key, command.request_digest,
-                         ResourceLocatorV1(resource_type="revision", resource_id=revision_id), now)
+            self._statblocks[command.statblock_id] = statblock.model_copy(
+                update={"latest_revision_id": revision_id}
+            )
+            self._record(
+                command.caller_scope,
+                "append_revision",
+                command.idempotency_key,
+                command.request_digest,
+                IdempotencyOutcomeV1(
+                    statblock_id=command.statblock_id, revision_id=revision_id
+                ),
+                now,
+            )
             return _copy(revision)
 
-    def _replay(self, scope: str, operation: str, key: str, digest: str) -> ResourceLocatorV1 | None:
+    def _replay(
+        self, scope: str, operation: str, key: str, digest: str
+    ) -> IdempotencyOutcomeV1 | None:
         record = self._idempotency.get((scope, operation, key))
         if record is None:
             return None
@@ -167,27 +248,41 @@ class InMemoryStatblockPersistenceRepository:
             raise IdempotencyConflictError(key)
         return record.outcome
 
-    def _record(self, scope: str, operation: str, key: str, digest: str, outcome: ResourceLocatorV1, now: datetime) -> None:
+    def _record(
+        self,
+        scope: str,
+        operation: str,
+        key: str,
+        digest: str,
+        outcome: IdempotencyOutcomeV1,
+        now: datetime,
+    ) -> None:
         self._idempotency[(scope, operation, key)] = IdempotencyRecordV1(
-            caller_scope=scope, operation=operation, idempotency_key=key, request_digest=digest,
-            outcome=outcome, created_at=now,
+            caller_scope=scope,
+            operation=operation,
+            idempotency_key=key,
+            request_digest=digest,
+            outcome=outcome,
+            created_at=now,
         )
 
 
-def _persistence_material(definition):
+def _persistence_material(definition: StatblockDefinitionV1):
     receipt = validate_definition(definition, ValidationMode.persistence)
-    from statblocks_v1.domain.errors import PersistenceValidationError
     if not receipt.is_persistence_ready:
         raise PersistenceValidationError()
     canonical = canonicalize_definition(definition)
-    digest = compute_definition_digest(canonical)
+    digest = compute_definition_digest(definition)
     if receipt.definition_digest != digest:
         raise PersistenceValidationError()
     return canonical, digest, receipt
 
 
 def _provenance(provenance: dict, candidate_id: str | None) -> dict:
-    return {**provenance, **({"candidate_id": candidate_id} if candidate_id else {})}
+    merged = {**provenance}
+    if candidate_id:
+        merged["candidate_id"] = candidate_id
+    return merged
 
 
 def _copy(model):

--- a/statblocks_v1/infrastructure/memory_repositories.py
+++ b/statblocks_v1/infrastructure/memory_repositories.py
@@ -1,0 +1,194 @@
+"""Deterministic, thread-safe in-memory repositories for statblock v1 tests."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from threading import RLock
+from typing import Callable
+
+from statblocks_v1.application.repositories import (
+    AppendRevisionCommand,
+    CreateStatblockCommand,
+)
+from statblocks_v1.domain.canonicalization import canonicalize_definition
+from statblocks_v1.domain.digests import compute_definition_digest
+from statblocks_v1.domain.errors import (
+    CandidateExpiredError,
+    CandidateNotFoundError,
+    IdempotencyConflictError,
+    ParentRevisionMismatchError,
+    RevisionNotFoundError,
+    StatblockNotFoundError,
+)
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
+    IdempotencyRecordV1,
+    ResourceLocatorV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
+from statblocks_v1.domain.validation import validate_definition
+
+Clock = Callable[[], datetime]
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class DeterministicIdFactory:
+    """Monotonic test ID factory; production adapters use Firestore-safe UUIDs."""
+
+    def __init__(self) -> None:
+        self._sequence = 0
+
+    def __call__(self, prefix: str) -> str:
+        self._sequence += 1
+        return f"{prefix}_{self._sequence:06d}"
+
+
+class InMemoryCandidateRepository:
+    def __init__(self, *, clock: Clock = utc_now) -> None:
+        self._clock = clock
+        self._candidates: dict[str, GeneratedStatblockCandidateV1] = {}
+
+    def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1:
+        self._candidates[candidate.candidate_id] = _copy(candidate)
+        return _copy(candidate)
+
+    def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1:
+        candidate = self._candidates.get(candidate_id)
+        if candidate is None:
+            raise CandidateNotFoundError(candidate_id)
+        if candidate.expires_at <= (now or self._clock()):
+            raise CandidateExpiredError(candidate_id)
+        return _copy(candidate)
+
+
+class InMemoryStatblockPersistenceRepository:
+    """One lock models the atomicity expected from the Firestore implementation."""
+
+    def __init__(
+        self,
+        *,
+        clock: Clock = utc_now,
+        id_factory: Callable[[str], str] | None = None,
+    ) -> None:
+        self._clock = clock
+        self._id_factory = id_factory or DeterministicIdFactory()
+        self._lock = RLock()
+        self._statblocks: dict[str, StatblockResourceV1] = {}
+        self._revisions: dict[tuple[str, str], StatblockRevisionResourceV1] = {}
+        self._idempotency: dict[tuple[str, str, str], IdempotencyRecordV1] = {}
+
+    def get(self, statblock_id: str) -> StatblockResourceV1:
+        statblock = self._statblocks.get(statblock_id)
+        if statblock is None:
+            raise StatblockNotFoundError(statblock_id)
+        return _copy(statblock)
+
+    def get_idempotency(
+        self, caller_scope: str, operation: str, idempotency_key: str
+    ) -> IdempotencyRecordV1 | None:
+        record = self._idempotency.get((caller_scope, operation, idempotency_key))
+        return _copy(record) if record else None
+
+    def get_revision(self, statblock_id: str, revision_id: str) -> StatblockRevisionResourceV1:
+        if statblock_id not in self._statblocks:
+            raise StatblockNotFoundError(statblock_id)
+        revision = self._revisions.get((statblock_id, revision_id))
+        if revision is None:
+            raise RevisionNotFoundError(revision_id)
+        return _copy(revision)
+
+    def list_for_statblock(self, statblock_id: str) -> list[StatblockRevisionResourceV1]:
+        if statblock_id not in self._statblocks:
+            raise StatblockNotFoundError(statblock_id)
+        return [
+            _copy(revision)
+            for (owner, _), revision in self._revisions.items()
+            if owner == statblock_id
+        ]
+
+    def create_statblock(
+        self, command: CreateStatblockCommand
+    ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
+        with self._lock:
+            replay = self._replay(command.caller_scope, "create_statblock", command.idempotency_key, command.request_digest)
+            if replay:
+                statblock = self.get(replay.resource_id)
+                return statblock, self.get_revision(statblock.statblock_id, statblock.latest_revision_id)
+            canonical, digest, receipt = _persistence_material(command.definition)
+            now = self._clock()
+            statblock_id, revision_id = self._id_factory("sb"), self._id_factory("rev")
+            statblock = StatblockResourceV1(
+                statblock_id=statblock_id, latest_revision_id=revision_id, created_at=now, created_by=command.created_by
+            )
+            revision = StatblockRevisionResourceV1(
+                statblock_id=statblock_id, revision_id=revision_id, definition=command.definition,
+                canonical_definition=canonical, definition_digest=digest, validation_receipt=receipt,
+                provenance=_provenance(command.provenance, command.candidate_id),
+                asset_bindings=command.asset_bindings, created_at=now,
+            )
+            self._statblocks[statblock_id], self._revisions[(statblock_id, revision_id)] = statblock, revision
+            self._record(command.caller_scope, "create_statblock", command.idempotency_key, command.request_digest,
+                         ResourceLocatorV1(resource_type="statblock", resource_id=statblock_id), now)
+            return _copy(statblock), _copy(revision)
+
+    def append_revision(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1:
+        with self._lock:
+            replay = self._replay(command.caller_scope, "append_revision", command.idempotency_key, command.request_digest)
+            if replay:
+                return self.get_revision(command.statblock_id, replay.resource_id)
+            statblock = self._statblocks.get(command.statblock_id)
+            if statblock is None:
+                raise StatblockNotFoundError(command.statblock_id)
+            if (command.statblock_id, command.parent_revision_id) not in self._revisions:
+                raise ParentRevisionMismatchError(command.statblock_id, command.parent_revision_id)
+            canonical, digest, receipt = _persistence_material(command.definition)
+            now, revision_id = self._clock(), self._id_factory("rev")
+            revision = StatblockRevisionResourceV1(
+                statblock_id=command.statblock_id, revision_id=revision_id, parent_revision_id=command.parent_revision_id,
+                definition=command.definition, canonical_definition=canonical, definition_digest=digest,
+                validation_receipt=receipt, provenance=_provenance(command.provenance, command.candidate_id),
+                asset_bindings=command.asset_bindings, created_at=now,
+            )
+            self._revisions[(command.statblock_id, revision_id)] = revision
+            self._statblocks[command.statblock_id] = statblock.model_copy(update={"latest_revision_id": revision_id})
+            self._record(command.caller_scope, "append_revision", command.idempotency_key, command.request_digest,
+                         ResourceLocatorV1(resource_type="revision", resource_id=revision_id), now)
+            return _copy(revision)
+
+    def _replay(self, scope: str, operation: str, key: str, digest: str) -> ResourceLocatorV1 | None:
+        record = self._idempotency.get((scope, operation, key))
+        if record is None:
+            return None
+        if record.request_digest != digest:
+            raise IdempotencyConflictError(key)
+        return record.outcome
+
+    def _record(self, scope: str, operation: str, key: str, digest: str, outcome: ResourceLocatorV1, now: datetime) -> None:
+        self._idempotency[(scope, operation, key)] = IdempotencyRecordV1(
+            caller_scope=scope, operation=operation, idempotency_key=key, request_digest=digest,
+            outcome=outcome, created_at=now,
+        )
+
+
+def _persistence_material(definition):
+    receipt = validate_definition(definition, ValidationMode.persistence)
+    from statblocks_v1.domain.errors import PersistenceValidationError
+    if not receipt.is_persistence_ready:
+        raise PersistenceValidationError()
+    canonical = canonicalize_definition(definition)
+    digest = compute_definition_digest(canonical)
+    if receipt.definition_digest != digest:
+        raise PersistenceValidationError()
+    return canonical, digest, receipt
+
+
+def _provenance(provenance: dict, candidate_id: str | None) -> dict:
+    return {**provenance, **({"candidate_id": candidate_id} if candidate_id else {})}
+
+
+def _copy(model):
+    return model.model_copy(deep=True)

--- a/tests/statblocks_v1/integration/test_firestore_repositories.py
+++ b/tests/statblocks_v1/integration/test_firestore_repositories.py
@@ -1,0 +1,25 @@
+"""Firestore emulator coverage; skipped unless FIRESTORE_EMULATOR_HOST is set."""
+import os
+
+import pytest
+
+pytestmark = pytest.mark.firestore_emulator
+
+
+@pytest.fixture
+def firestore_client():
+    if not os.environ.get("FIRESTORE_EMULATOR_HOST"):
+        pytest.skip("Firestore emulator is not configured")
+    from google.cloud import firestore
+    return firestore.Client(project=os.environ.get("GOOGLE_CLOUD_PROJECT", "statblocks-v1-test"))
+
+
+def test_v1_collection_layout_is_isolated(firestore_client):
+    from statblocks_v1.infrastructure.firestore_repositories import (
+        CANDIDATES_COLLECTION, IDEMPOTENCY_COLLECTION, STATBLOCKS_COLLECTION,
+    )
+    assert (CANDIDATES_COLLECTION, STATBLOCKS_COLLECTION, IDEMPOTENCY_COLLECTION) == (
+        "dungeonbuddy_statblock_candidates_v1",
+        "dungeonbuddy_statblocks_v1",
+        "dungeonbuddy_statblock_idempotency_v1",
+    )

--- a/tests/statblocks_v1/integration/test_firestore_repositories.py
+++ b/tests/statblocks_v1/integration/test_firestore_repositories.py
@@ -1,7 +1,26 @@
 """Firestore emulator coverage; skipped unless FIRESTORE_EMULATOR_HOST is set."""
+from __future__ import annotations
+
 import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 
 import pytest
+
+from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
+from statblocks_v1.domain.errors import StaleParentRevisionError, StatblockNotFoundError
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import GeneratedStatblockCandidateV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.validation import validate_definition
+from statblocks_v1.infrastructure.firestore_repositories import (
+    CANDIDATES_COLLECTION,
+    IDEMPOTENCY_COLLECTION,
+    STATBLOCKS_COLLECTION,
+    FirestoreCandidateRepository,
+    FirestoreStatblockPersistenceRepository,
+    _dump,
+)
 
 pytestmark = pytest.mark.firestore_emulator
 
@@ -11,15 +30,139 @@ def firestore_client():
     if not os.environ.get("FIRESTORE_EMULATOR_HOST"):
         pytest.skip("Firestore emulator is not configured")
     from google.cloud import firestore
-    return firestore.Client(project=os.environ.get("GOOGLE_CLOUD_PROJECT", "statblocks-v1-test"))
 
-
-def test_v1_collection_layout_is_isolated(firestore_client):
-    from statblocks_v1.infrastructure.firestore_repositories import (
-        CANDIDATES_COLLECTION, IDEMPOTENCY_COLLECTION, STATBLOCKS_COLLECTION,
+    return firestore.Client(
+        project=os.environ.get("GOOGLE_CLOUD_PROJECT", "statblocks-v1-test")
     )
+
+
+@pytest.fixture
+def bruiser(load_fixture):
+    return StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+
+
+def test_v1_collection_layout_is_isolated():
     assert (CANDIDATES_COLLECTION, STATBLOCKS_COLLECTION, IDEMPOTENCY_COLLECTION) == (
         "dungeonbuddy_statblock_candidates_v1",
         "dungeonbuddy_statblocks_v1",
         "dungeonbuddy_statblock_idempotency_v1",
     )
+
+
+def test_dump_preserves_native_timestamps_for_ttl_fields(bruiser):
+    created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    expires = created + timedelta(hours=1)
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id="cand_ttl001",
+        definition=bruiser,
+        validation_receipt=validate_definition(bruiser, ValidationMode.generation_candidate),
+        created_at=created,
+        expires_at=expires,
+    )
+    dumped = _dump(candidate)
+    assert isinstance(dumped["expires_at"], datetime)
+    assert isinstance(dumped["created_at"], datetime)
+    assert dumped["expires_at"] == expires
+
+
+def test_firestore_create_round_trip_and_create_replay(firestore_client, bruiser):
+    repository = FirestoreStatblockPersistenceRepository(firestore_client)
+    command = CreateStatblockCommand(
+        caller_scope="dungeonbuddy",
+        idempotency_key="fs-create-1",
+        definition=bruiser,
+        created_by="dungeonbuddy",
+    )
+    statblock, first = repository.create_statblock(command)
+    repository.append_revision(
+        AppendRevisionCommand(
+            caller_scope="dungeonbuddy",
+            idempotency_key="fs-append-1",
+            statblock_id=statblock.statblock_id,
+            parent_revision_id=first.revision_id,
+            definition=bruiser,
+        )
+    )
+    replay_statblock, replay_revision = repository.create_statblock(command)
+    assert replay_revision.revision_id == first.revision_id
+    assert replay_statblock.statblock_id == statblock.statblock_id
+
+    loaded = repository.get_revision(statblock.statblock_id, first.revision_id)
+    assert loaded.canonical_definition == first.canonical_definition
+    assert loaded.definition_digest == first.definition_digest
+
+
+def test_firestore_candidate_ttl_timestamp_round_trip(firestore_client, bruiser):
+    repository = FirestoreCandidateRepository(firestore_client)
+    created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    expires = created + timedelta(hours=2)
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id="cand_fs0001",
+        definition=bruiser,
+        validation_receipt=validate_definition(bruiser, ValidationMode.generation_candidate),
+        created_at=created,
+        expires_at=expires,
+    )
+    repository.create(candidate)
+    snapshot = (
+        firestore_client.collection(CANDIDATES_COLLECTION)
+        .document(candidate.candidate_id)
+        .get()
+    )
+    raw = snapshot.to_dict()
+    assert isinstance(raw["expires_at"], datetime)
+    loaded = repository.get(candidate.candidate_id, now=created)
+    assert loaded.expires_at == expires
+
+
+def test_firestore_concurrent_append_only_one_succeeds(firestore_client, bruiser):
+    repository = FirestoreStatblockPersistenceRepository(firestore_client)
+    statblock, first = repository.create_statblock(
+        CreateStatblockCommand(
+            caller_scope="dungeonbuddy",
+            idempotency_key="fs-create-concurrent",
+            definition=bruiser,
+            created_by="dungeonbuddy",
+        )
+    )
+
+    def attempt(key: str):
+        return repository.append_revision(
+            AppendRevisionCommand(
+                caller_scope="dungeonbuddy",
+                idempotency_key=key,
+                statblock_id=statblock.statblock_id,
+                parent_revision_id=first.revision_id,
+                definition=bruiser,
+            )
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(attempt, "fs-append-a"), pool.submit(attempt, "fs-append-b")]
+        results = []
+        errors = []
+        for future in futures:
+            try:
+                results.append(future.result())
+            except Exception as error:  # noqa: BLE001 - assert typed stale-parent below
+                errors.append(error)
+
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], StaleParentRevisionError)
+    assert repository.get(statblock.statblock_id).latest_revision_id == results[0].revision_id
+    assert len(repository.list_for_statblock(statblock.statblock_id)) == 2
+
+
+def test_firestore_missing_statblock_is_not_parent_mismatch(firestore_client, bruiser):
+    repository = FirestoreStatblockPersistenceRepository(firestore_client)
+    with pytest.raises(StatblockNotFoundError):
+        repository.append_revision(
+            AppendRevisionCommand(
+                caller_scope="dungeonbuddy",
+                idempotency_key="fs-missing-sb",
+                statblock_id="sb_doesnotexist01",
+                parent_revision_id="rev_doesnotexist01",
+                definition=bruiser,
+            )
+        )

--- a/tests/statblocks_v1/test_firestore_transaction_semantics.py
+++ b/tests/statblocks_v1/test_firestore_transaction_semantics.py
@@ -21,6 +21,7 @@ from statblocks_v1.domain.errors import (
 )
 from statblocks_v1.domain.receipts import ValidationMode
 from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
     IdempotencyOutcomeV1,
     IdempotencyRecordV1,
     StatblockResourceV1,
@@ -29,6 +30,7 @@ from statblocks_v1.domain.resources import (
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
 from statblocks_v1.infrastructure.firestore_repositories import (
+    FirestoreCandidateRepository,
     FirestoreStatblockPersistenceRepository,
 )
 from statblocks_v1.infrastructure.memory_repositories import DeterministicIdFactory
@@ -211,7 +213,7 @@ def test_append_already_exists_uses_revision_id(load_fixture, monkeypatch):
 
     monkeypatch.setattr(repository, "get_idempotency", lambda *args, **kwargs: None)
 
-    def append_collision(cmd, revision):
+    def append_collision(cmd, revision, *, request_digest):
         raise ImmutableRevisionConflictError(revision.revision_id)
 
     monkeypatch.setattr(repository, "_transactional_append", append_collision)
@@ -219,3 +221,33 @@ def test_append_already_exists_uses_revision_id(load_fixture, monkeypatch):
     with pytest.raises(ImmutableRevisionConflictError) as exc:
         repository.append_revision(command)
     assert exc.value.details == {"revision_id": "rev_000001"}
+
+
+def test_candidate_create_maps_client_failures_to_persistence_unavailable(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+
+    class _DeadlineExceeded(Exception):
+        pass
+
+    class _FailingCollection:
+        def document(self, _candidate_id: str):
+            return SimpleNamespace(
+                create=lambda _payload: (_ for _ in ()).throw(
+                    _DeadlineExceeded("deadline exceeded")
+                )
+            )
+
+    client = SimpleNamespace(collection=lambda _name: _FailingCollection())
+    repository = FirestoreCandidateRepository(client, clock=_clock)
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id="cand_fail001",
+        definition=definition,
+        validation_receipt=validate_definition(
+            definition, ValidationMode.generation_candidate
+        ),
+        created_at=_clock(),
+        expires_at=_clock(),
+    )
+
+    with pytest.raises(PersistenceUnavailableError):
+        repository.create(candidate)

--- a/tests/statblocks_v1/test_firestore_transaction_semantics.py
+++ b/tests/statblocks_v1/test_firestore_transaction_semantics.py
@@ -1,0 +1,221 @@
+"""Unit coverage for Firestore transaction failure classification and reconciliation.
+
+These tests do not require the emulator; they inject commit-then-error behavior at
+the repository seam used by create/append.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
+from statblocks_v1.domain.canonicalization import canonicalize_definition
+from statblocks_v1.domain.digests import compute_definition_digest
+from statblocks_v1.domain.errors import (
+    ImmutableResourceConflictError,
+    ImmutableRevisionConflictError,
+    PersistenceUnavailableError,
+    TransactionIndeterminateError,
+)
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import (
+    IdempotencyOutcomeV1,
+    IdempotencyRecordV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.validation import validate_definition
+from statblocks_v1.infrastructure.firestore_repositories import (
+    FirestoreStatblockPersistenceRepository,
+)
+from statblocks_v1.infrastructure.memory_repositories import DeterministicIdFactory
+
+
+def _clock():
+    return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class _FakeClient:
+    """Minimal client so `_document` / `_run_transaction` can be unit-tested."""
+
+    def transaction(self):
+        return object()
+
+    def collection(self, name: str):
+        return SimpleNamespace(
+            document=lambda document_id: SimpleNamespace(
+                path=f"{name}/{document_id}",
+                collection=lambda sub: SimpleNamespace(
+                    document=lambda sub_id: SimpleNamespace(path=f"{name}/{document_id}/{sub}/{sub_id}")
+                ),
+            )
+        )
+
+
+class _DeadlineExceeded(Exception):
+    """Stand-in for google.api_core.exceptions.DeadlineExceeded."""
+
+
+def test_run_transaction_maps_deadline_to_indeterminate_not_unavailable():
+    repository = FirestoreStatblockPersistenceRepository(client=_FakeClient(), clock=_clock)
+
+    def boom(_transaction):
+        raise _DeadlineExceeded("deadline exceeded")
+
+    with pytest.raises(TransactionIndeterminateError):
+        repository._run_transaction(
+            boom,
+            already_exists=ImmutableResourceConflictError("statblock", "sb_x"),
+        )
+
+
+def test_run_transaction_maps_already_exists_to_provided_typed_error():
+    repository = FirestoreStatblockPersistenceRepository(client=_FakeClient(), clock=_clock)
+
+    class AlreadyExists(Exception):
+        pass
+
+    def boom(_transaction):
+        raise AlreadyExists("document already exists")
+
+    with pytest.raises(ImmutableResourceConflictError) as exc:
+        repository._run_transaction(
+            boom,
+            already_exists=ImmutableResourceConflictError("statblock", "sb_fixed01"),
+        )
+    assert exc.value.details == {
+        "resource_type": "statblock",
+        "resource_id": "sb_fixed01",
+    }
+
+    with pytest.raises(ImmutableRevisionConflictError) as rev_exc:
+        repository._run_transaction(
+            boom,
+            already_exists=ImmutableRevisionConflictError("rev_fixed01"),
+        )
+    assert rev_exc.value.details == {"revision_id": "rev_fixed01"}
+
+
+def test_create_reconciles_exact_outcome_after_indeterminate_commit(load_fixture, monkeypatch):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    factory = DeterministicIdFactory()
+    repository = FirestoreStatblockPersistenceRepository(
+        client=_FakeClient(), clock=_clock, id_factory=factory
+    )
+    command = CreateStatblockCommand(
+        caller_scope="dungeonbuddy",
+        idempotency_key="reconcile-create",
+        definition=definition,
+        created_by="dungeonbuddy",
+    )
+    expected_statblock_id = "sb_000001"
+    expected_revision_id = "rev_000002"
+    receipt = validate_definition(definition, ValidationMode.persistence)
+    canonical = str(canonicalize_definition(definition))
+    digest = compute_definition_digest(definition)
+    stored_statblock = StatblockResourceV1(
+        statblock_id=expected_statblock_id,
+        latest_revision_id=expected_revision_id,
+        created_at=_clock(),
+        created_by="dungeonbuddy",
+    )
+    stored_revision = StatblockRevisionResourceV1(
+        statblock_id=expected_statblock_id,
+        revision_id=expected_revision_id,
+        definition=definition,
+        canonical_definition=canonical,
+        definition_digest=digest,
+        validation_receipt=receipt,
+        created_at=_clock(),
+    )
+    record = IdempotencyRecordV1(
+        caller_scope="dungeonbuddy",
+        operation="create_statblock",
+        idempotency_key="reconcile-create",
+        request_digest=command.request_digest,
+        outcome=IdempotencyOutcomeV1(
+            statblock_id=expected_statblock_id, revision_id=expected_revision_id
+        ),
+        created_at=_clock(),
+    )
+
+    calls = {"n": 0}
+
+    def get_idempotency(scope, operation, key):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return record
+
+    monkeypatch.setattr(repository, "get_idempotency", get_idempotency)
+    monkeypatch.setattr(
+        repository,
+        "_transactional_write",
+        lambda *args, **kwargs: (_ for _ in ()).throw(TransactionIndeterminateError()),
+    )
+    monkeypatch.setattr(repository, "get", lambda sid: stored_statblock)
+    monkeypatch.setattr(repository, "get_revision", lambda sid, rid: stored_revision)
+
+    statblock, revision = repository.create_statblock(command)
+    assert statblock.statblock_id == expected_statblock_id
+    assert revision.revision_id == expected_revision_id
+    assert factory._sequence == 2
+
+
+def test_create_indeterminate_when_reconcile_read_unavailable(load_fixture, monkeypatch):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = FirestoreStatblockPersistenceRepository(
+        client=_FakeClient(), clock=_clock, id_factory=DeterministicIdFactory()
+    )
+    command = CreateStatblockCommand(
+        caller_scope="dungeonbuddy",
+        idempotency_key="reconcile-unavailable",
+        definition=definition,
+        created_by="dungeonbuddy",
+    )
+
+    calls = {"n": 0}
+
+    def get_idempotency(scope, operation, key):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        raise PersistenceUnavailableError()
+
+    monkeypatch.setattr(repository, "get_idempotency", get_idempotency)
+    monkeypatch.setattr(
+        repository,
+        "_transactional_write",
+        lambda *args, **kwargs: (_ for _ in ()).throw(TransactionIndeterminateError()),
+    )
+
+    with pytest.raises(TransactionIndeterminateError):
+        repository.create_statblock(command)
+
+
+def test_append_already_exists_uses_revision_id(load_fixture, monkeypatch):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = FirestoreStatblockPersistenceRepository(
+        client=_FakeClient(), clock=_clock, id_factory=DeterministicIdFactory()
+    )
+    command = AppendRevisionCommand(
+        caller_scope="dungeonbuddy",
+        idempotency_key="append-collision",
+        statblock_id="sb_000001",
+        parent_revision_id="rev_000001",
+        definition=definition,
+    )
+
+    monkeypatch.setattr(repository, "get_idempotency", lambda *args, **kwargs: None)
+
+    def append_collision(cmd, revision):
+        raise ImmutableRevisionConflictError(revision.revision_id)
+
+    monkeypatch.setattr(repository, "_transactional_append", append_collision)
+
+    with pytest.raises(ImmutableRevisionConflictError) as exc:
+        repository.append_revision(command)
+    assert exc.value.details == {"revision_id": "rev_000001"}

--- a/tests/statblocks_v1/test_memory_repositories.py
+++ b/tests/statblocks_v1/test_memory_repositories.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
+from statblocks_v1.domain.errors import CandidateExpiredError, IdempotencyConflictError, ParentRevisionMismatchError
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import GeneratedStatblockCandidateV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.validation import validate_definition
+from statblocks_v1.infrastructure.memory_repositories import (
+    DeterministicIdFactory, InMemoryCandidateRepository, InMemoryStatblockPersistenceRepository,
+)
+
+
+def _clock():
+    return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _repository():
+    return InMemoryStatblockPersistenceRepository(clock=_clock, id_factory=DeterministicIdFactory())
+
+
+def _create(definition, key="create-1", created_by="dungeonbuddy"):
+    return CreateStatblockCommand(
+        caller_scope="dungeonbuddy", idempotency_key=key, definition=definition, created_by=created_by
+    )
+
+
+def test_create_append_replay_and_immutable_history(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = _repository()
+    statblock, first = repository.create_statblock(_create(definition))
+    second = repository.append_revision(AppendRevisionCommand(
+        caller_scope="dungeonbuddy", idempotency_key="append-1", statblock_id=statblock.statblock_id,
+        parent_revision_id=first.revision_id, definition=definition,
+    ))
+    replay = repository.append_revision(AppendRevisionCommand(
+        caller_scope="dungeonbuddy", idempotency_key="append-1", statblock_id=statblock.statblock_id,
+        parent_revision_id=first.revision_id, definition=definition,
+    ))
+
+    assert replay.revision_id == second.revision_id
+    assert repository.get(statblock.statblock_id).latest_revision_id == second.revision_id
+    assert repository.get_revision(statblock.statblock_id, first.revision_id) == first
+    assert first.definition_digest == second.definition_digest  # same mechanics can be intentionally accepted twice
+
+
+def test_idempotency_conflict_and_parent_mismatch(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = _repository()
+    statblock, first = repository.create_statblock(_create(definition))
+    with pytest.raises(IdempotencyConflictError):
+        repository.create_statblock(_create(definition, key="create-1", created_by="other-service"))
+    with pytest.raises(ParentRevisionMismatchError):
+        repository.append_revision(AppendRevisionCommand(
+            caller_scope="dungeonbuddy", idempotency_key="append-1", statblock_id=statblock.statblock_id,
+            parent_revision_id="rev_999999", definition=definition,
+        ))
+
+
+def test_candidate_expiration(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    created = _clock()
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id="cand_000001", definition=definition,
+        validation_receipt=validate_definition(definition, ValidationMode.generation_candidate),
+        created_at=created, expires_at=created + timedelta(minutes=1),
+    )
+    repository = InMemoryCandidateRepository(clock=_clock)
+    repository.create(candidate)
+    with pytest.raises(CandidateExpiredError):
+        repository.get(candidate.candidate_id, now=created + timedelta(minutes=1))

--- a/tests/statblocks_v1/test_memory_repositories.py
+++ b/tests/statblocks_v1/test_memory_repositories.py
@@ -1,15 +1,33 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
-from statblocks_v1.domain.errors import CandidateExpiredError, IdempotencyConflictError, ParentRevisionMismatchError
+from statblocks_v1.application.repositories import (
+    AppendRevisionCommand,
+    CreateStatblockCommand,
+    compute_request_digest,
+)
+from statblocks_v1.domain.canonicalization import canonicalize_definition
+from statblocks_v1.domain.digests import compute_definition_digest
+from statblocks_v1.domain.errors import (
+    CandidateExpiredError,
+    IdempotencyConflictError,
+    ImmutableResourceConflictError,
+    ImmutableRevisionConflictError,
+    ParentRevisionMismatchError,
+    StaleParentRevisionError,
+    StatblockNotFoundError,
+)
 from statblocks_v1.domain.receipts import ValidationMode
 from statblocks_v1.domain.resources import GeneratedStatblockCandidateV1
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
 from statblocks_v1.infrastructure.memory_repositories import (
-    DeterministicIdFactory, InMemoryCandidateRepository, InMemoryStatblockPersistenceRepository,
+    DeterministicIdFactory,
+    InMemoryCandidateRepository,
+    InMemoryStatblockPersistenceRepository,
 )
 
 
@@ -17,13 +35,30 @@ def _clock():
     return datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
-def _repository():
-    return InMemoryStatblockPersistenceRepository(clock=_clock, id_factory=DeterministicIdFactory())
+def _repository(id_factory=None):
+    return InMemoryStatblockPersistenceRepository(
+        clock=_clock, id_factory=id_factory or DeterministicIdFactory()
+    )
 
 
-def _create(definition, key="create-1", created_by="dungeonbuddy"):
+def _create(definition, key="create-1", created_by="dungeonbuddy", **kwargs):
     return CreateStatblockCommand(
-        caller_scope="dungeonbuddy", idempotency_key=key, definition=definition, created_by=created_by
+        caller_scope="dungeonbuddy",
+        idempotency_key=key,
+        definition=definition,
+        created_by=created_by,
+        **kwargs,
+    )
+
+
+def _append(definition, statblock_id, parent_revision_id, key="append-1", **kwargs):
+    return AppendRevisionCommand(
+        caller_scope="dungeonbuddy",
+        idempotency_key=key,
+        statblock_id=statblock_id,
+        parent_revision_id=parent_revision_id,
+        definition=definition,
+        **kwargs,
     )
 
 
@@ -31,43 +66,229 @@ def test_create_append_replay_and_immutable_history(load_fixture):
     definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
     repository = _repository()
     statblock, first = repository.create_statblock(_create(definition))
-    second = repository.append_revision(AppendRevisionCommand(
-        caller_scope="dungeonbuddy", idempotency_key="append-1", statblock_id=statblock.statblock_id,
-        parent_revision_id=first.revision_id, definition=definition,
-    ))
-    replay = repository.append_revision(AppendRevisionCommand(
-        caller_scope="dungeonbuddy", idempotency_key="append-1", statblock_id=statblock.statblock_id,
-        parent_revision_id=first.revision_id, definition=definition,
-    ))
+    second = repository.append_revision(
+        _append(definition, statblock.statblock_id, first.revision_id)
+    )
+    replay = repository.append_revision(
+        _append(definition, statblock.statblock_id, first.revision_id)
+    )
 
     assert replay.revision_id == second.revision_id
     assert repository.get(statblock.statblock_id).latest_revision_id == second.revision_id
     assert repository.get_revision(statblock.statblock_id, first.revision_id) == first
-    assert first.definition_digest == second.definition_digest  # same mechanics can be intentionally accepted twice
+    assert first.definition_digest == second.definition_digest
+    assert first.canonical_definition == str(canonicalize_definition(definition))
+    assert first.definition_digest == compute_definition_digest(definition)
+    assert first.validation_receipt.definition_digest == first.definition_digest
 
 
-def test_idempotency_conflict_and_parent_mismatch(load_fixture):
+def test_create_retry_after_append_returns_original_revision(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = _repository()
+    statblock, first = repository.create_statblock(_create(definition, key="create-1"))
+    repository.append_revision(
+        _append(definition, statblock.statblock_id, first.revision_id, key="append-1")
+    )
+
+    replay_statblock, replay_revision = repository.create_statblock(
+        _create(definition, key="create-1")
+    )
+
+    assert replay_statblock.statblock_id == statblock.statblock_id
+    assert replay_revision.revision_id == first.revision_id
+    assert replay_revision.parent_revision_id is None
+    assert repository.get(statblock.statblock_id).latest_revision_id != first.revision_id
+
+
+def test_stale_parent_append_rejected_without_writing(load_fixture):
     definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
     repository = _repository()
     statblock, first = repository.create_statblock(_create(definition))
-    with pytest.raises(IdempotencyConflictError):
-        repository.create_statblock(_create(definition, key="create-1", created_by="other-service"))
+    second = repository.append_revision(
+        _append(definition, statblock.statblock_id, first.revision_id, key="append-a")
+    )
+
+    with pytest.raises(StaleParentRevisionError):
+        repository.append_revision(
+            _append(definition, statblock.statblock_id, first.revision_id, key="append-b")
+        )
+
+    assert repository.get(statblock.statblock_id).latest_revision_id == second.revision_id
+    assert repository.get_idempotency("dungeonbuddy", "append_revision", "append-b") is None
+    assert len(repository.list_for_statblock(statblock.statblock_id)) == 2
+
+
+def test_missing_statblock_parent_and_foreign_parent_are_distinct(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = _repository()
+    first_block, first = repository.create_statblock(_create(definition, key="a"))
+    second_block, second = repository.create_statblock(_create(definition, key="b"))
+
+    with pytest.raises(StatblockNotFoundError):
+        repository.append_revision(
+            _append(definition, "sb_missing", first.revision_id, key="append-missing")
+        )
     with pytest.raises(ParentRevisionMismatchError):
-        repository.append_revision(AppendRevisionCommand(
-            caller_scope="dungeonbuddy", idempotency_key="append-1", statblock_id=statblock.statblock_id,
-            parent_revision_id="rev_999999", definition=definition,
-        ))
+        repository.append_revision(
+            _append(
+                definition,
+                first_block.statblock_id,
+                "rev_999999",
+                key="append-missing-parent",
+            )
+        )
+    with pytest.raises(ParentRevisionMismatchError):
+        repository.append_revision(
+            _append(
+                definition,
+                first_block.statblock_id,
+                second.revision_id,
+                key="append-foreign-parent",
+            )
+        )
+
+
+def test_idempotency_conflict_and_canonical_request_digest(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = _repository()
+    repository.create_statblock(_create(definition, key="create-1"))
+
+    with pytest.raises(IdempotencyConflictError):
+        repository.create_statblock(
+            _create(definition, key="create-1", created_by="other-service")
+        )
+
+    payload = load_fixture("simple_bruiser")
+    payload["identity"]["name"] = "Café"
+    composed = StatblockDefinitionV1.model_validate(payload)
+    payload["identity"]["name"] = "Cafe\u0301"
+    decomposed = StatblockDefinitionV1.model_validate(payload)
+    assert _create(composed).request_digest == _create(decomposed).request_digest
+
+    with_subtypes = definition.model_copy(
+        update={
+            "identity": definition.identity.model_copy(
+                update={"subtypes": ["fiend", "demon"]}
+            )
+        }
+    )
+    reordered = with_subtypes.model_copy(
+        update={
+            "identity": with_subtypes.identity.model_copy(
+                update={"subtypes": ["demon", "fiend"]}
+            )
+        }
+    )
+    assert _create(with_subtypes).request_digest == _create(reordered).request_digest
+
+    changed = _create(definition, provenance={"note": "x"})
+    assert changed.request_digest != _create(definition).request_digest
+    assert compute_request_digest("create_statblock", {"x": 1}).startswith("sha256:")
+
+
+def test_caller_mutation_cannot_alter_stored_revision(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    expected_canonical = str(canonicalize_definition(definition))
+    expected_digest = compute_definition_digest(definition)
+    repository = _repository()
+    command = _create(
+        definition,
+        provenance={"source": "test"},
+        asset_bindings=[{"asset_id": "img_1"}],
+    )
+    _, revision = repository.create_statblock(command)
+
+    command.definition.identity.name = "Mutated After Store"
+    command.provenance["source"] = "mutated"
+    command.asset_bindings[0]["asset_id"] = "img_mutated"
+    returned = repository.get_revision(revision.statblock_id, revision.revision_id)
+    returned.definition.identity.name = "Mutated Returned Copy"
+    returned.provenance["source"] = "returned-mutated"
+
+    stored = repository.get_revision(revision.statblock_id, revision.revision_id)
+    assert stored.definition.identity.name == "Ironhide Brute"
+    assert stored.provenance == {"source": "test"}
+    assert stored.asset_bindings == [{"asset_id": "img_1"}]
+    assert stored.canonical_definition == expected_canonical
+    assert stored.definition_digest == expected_digest
+    assert compute_definition_digest(stored.definition) == stored.definition_digest
+
+
+def test_id_collisions_cannot_overwrite_history(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+
+    class CollisionFactory:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, prefix: str) -> str:
+            self.calls += 1
+            if prefix == "sb":
+                return "sb_fixed01"
+            return "rev_fixed01"
+
+    repository = _repository(id_factory=CollisionFactory())
+    repository.create_statblock(_create(definition, key="first"))
+    with pytest.raises(ImmutableResourceConflictError):
+        repository.create_statblock(_create(definition, key="second"))
+
+    candidate_repo = InMemoryCandidateRepository(clock=_clock)
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id="cand_000001",
+        definition=definition,
+        validation_receipt=validate_definition(
+            definition, ValidationMode.generation_candidate
+        ),
+        created_at=_clock(),
+        expires_at=_clock() + timedelta(minutes=1),
+    )
+    candidate_repo.create(candidate)
+    with pytest.raises(ImmutableResourceConflictError):
+        candidate_repo.create(candidate)
+
+    # Forced revision collision on append.
+    class RevisionCollisionFactory:
+        def __init__(self) -> None:
+            self.n = 0
+
+        def __call__(self, prefix: str) -> str:
+            self.n += 1
+            if prefix == "sb":
+                return f"sb_{self.n:06d}"
+            return "rev_dup001"
+
+    colliding = _repository(id_factory=RevisionCollisionFactory())
+    statblock, first = colliding.create_statblock(_create(definition, key="c1"))
+    with pytest.raises(ImmutableRevisionConflictError):
+        colliding.append_revision(
+            _append(definition, statblock.statblock_id, first.revision_id, key="a1")
+        )
 
 
 def test_candidate_expiration(load_fixture):
     definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
     created = _clock()
     candidate = GeneratedStatblockCandidateV1(
-        candidate_id="cand_000001", definition=definition,
-        validation_receipt=validate_definition(definition, ValidationMode.generation_candidate),
-        created_at=created, expires_at=created + timedelta(minutes=1),
+        candidate_id="cand_000001",
+        definition=definition,
+        validation_receipt=validate_definition(
+            definition, ValidationMode.generation_candidate
+        ),
+        created_at=created,
+        expires_at=created + timedelta(minutes=1),
     )
     repository = InMemoryCandidateRepository(clock=_clock)
     repository.create(candidate)
     with pytest.raises(CandidateExpiredError):
         repository.get(candidate.candidate_id, now=created + timedelta(minutes=1))
+
+
+def test_digest_api_still_rejects_non_definition_inputs(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    canonical = canonicalize_definition(definition)
+    with pytest.raises(TypeError):
+        compute_definition_digest(str(canonical))
+    with pytest.raises(TypeError):
+        compute_definition_digest(canonical)
+    with pytest.raises(TypeError):
+        compute_definition_digest(str(canonical).encode("utf-8"))

--- a/tests/statblocks_v1/test_memory_repositories.py
+++ b/tests/statblocks_v1/test_memory_repositories.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -12,6 +13,7 @@ from statblocks_v1.application.repositories import (
 from statblocks_v1.domain.canonicalization import canonicalize_definition
 from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import (
+    AmbiguousRequestPayloadError,
     CandidateExpiredError,
     IdempotencyConflictError,
     ImmutableResourceConflictError,
@@ -185,6 +187,20 @@ def test_idempotency_conflict_and_canonical_request_digest(load_fixture):
     assert changed.request_digest != _create(definition).request_digest
     assert compute_request_digest("create_statblock", {"x": 1}).startswith("sha256:")
 
+    # NFC-equivalent values remain equivalent; NFC-colliding keys fail closed.
+    assert compute_request_digest(
+        "create_statblock", {"note": "Café"}
+    ) == compute_request_digest("create_statblock", {"note": "Cafe\u0301"})
+    with pytest.raises(AmbiguousRequestPayloadError) as ambiguous:
+        compute_request_digest(
+            "create_statblock",
+            {"provenance": {"é": 1, "e\u0301": 2}},
+        )
+    assert ambiguous.value.details == {"key": "é"}
+    assert compute_request_digest(
+        "create_statblock", {"provenance": {"é": 1}}
+    ) != compute_request_digest("create_statblock", {"provenance": {"é": 2}})
+
 
 def test_caller_mutation_cannot_alter_stored_revision(load_fixture):
     definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
@@ -281,6 +297,49 @@ def test_candidate_expiration(load_fixture):
     repository.create(candidate)
     with pytest.raises(CandidateExpiredError):
         repository.get(candidate.candidate_id, now=created + timedelta(minutes=1))
+
+
+def test_concurrent_candidate_creates_are_atomic(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    created = _clock()
+    repository = InMemoryCandidateRepository(clock=_clock)
+
+    def make_candidate(tag: str) -> GeneratedStatblockCandidateV1:
+        return GeneratedStatblockCandidateV1(
+            candidate_id="cand_shared1",
+            definition=definition,
+            validation_receipt=validate_definition(
+                definition, ValidationMode.generation_candidate
+            ),
+            created_at=created,
+            expires_at=created + timedelta(minutes=5),
+            asset_brief={"tag": tag},
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(repository.create, make_candidate("a")),
+            pool.submit(repository.create, make_candidate("b")),
+        ]
+        results = []
+        errors = []
+        for future in futures:
+            try:
+                results.append(future.result())
+            except Exception as error:  # noqa: BLE001 - assert typed conflict below
+                errors.append(error)
+
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], ImmutableResourceConflictError)
+    assert errors[0].details == {
+        "resource_type": "candidate",
+        "resource_id": "cand_shared1",
+    }
+    stored = repository.get("cand_shared1", now=created)
+    assert stored.asset_brief == results[0].asset_brief
+    results[0].asset_brief["tag"] = "mutated"
+    assert repository.get("cand_shared1", now=created).asset_brief != {"tag": "mutated"}
 
 
 def test_digest_api_still_rejects_non_definition_inputs(load_fixture):

--- a/tests/statblocks_v1/test_memory_repositories.py
+++ b/tests/statblocks_v1/test_memory_repositories.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 
@@ -207,16 +208,28 @@ def test_caller_mutation_cannot_alter_stored_revision(load_fixture):
     expected_canonical = str(canonicalize_definition(definition))
     expected_digest = compute_definition_digest(definition)
     repository = _repository()
+    provenance = {"source": "test"}
+    assets = [{"asset_id": "img_1"}]
     command = _create(
         definition,
-        provenance={"source": "test"},
-        asset_bindings=[{"asset_id": "img_1"}],
+        provenance=provenance,
+        asset_bindings=assets,
     )
-    _, revision = repository.create_statblock(command)
+    frozen_digest = command.request_digest
 
-    command.definition.identity.name = "Mutated After Store"
-    command.provenance["source"] = "mutated"
-    command.asset_bindings[0]["asset_id"] = "img_mutated"
+    # Mutate the caller's originals and any returned property copies before/during create.
+    definition.identity.name = "Mutated Source Definition"
+    provenance["source"] = "mutated-source"
+    assets[0]["asset_id"] = "img_source_mutated"
+    command.definition.identity.name = "Mutated Property Copy"
+    command.provenance["source"] = "mutated-property"
+    command.asset_bindings[0]["asset_id"] = "img_property_mutated"
+    with pytest.raises(AttributeError):
+        command.created_by = "hijacked"
+
+    _, revision = repository.create_statblock(command)
+    assert command.request_digest == frozen_digest
+
     returned = repository.get_revision(revision.statblock_id, revision.revision_id)
     returned.definition.identity.name = "Mutated Returned Copy"
     returned.provenance["source"] = "returned-mutated"
@@ -227,7 +240,11 @@ def test_caller_mutation_cannot_alter_stored_revision(load_fixture):
     assert stored.asset_bindings == [{"asset_id": "img_1"}]
     assert stored.canonical_definition == expected_canonical
     assert stored.definition_digest == expected_digest
+    assert stored.validation_receipt.definition_digest == expected_digest
     assert compute_definition_digest(stored.definition) == stored.definition_digest
+    record = repository.get_idempotency("dungeonbuddy", "create_statblock", "create-1")
+    assert record is not None
+    assert record.request_digest == frozen_digest
 
 
 def test_id_collisions_cannot_overwrite_history(load_fixture):
@@ -351,3 +368,52 @@ def test_digest_api_still_rejects_non_definition_inputs(load_fixture):
         compute_definition_digest(canonical)
     with pytest.raises(TypeError):
         compute_definition_digest(str(canonical).encode("utf-8"))
+
+
+def test_concurrent_readers_observe_committed_state_only(load_fixture):
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    repository = _repository()
+    statblock, first = repository.create_statblock(_create(definition))
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def writer() -> None:
+        parent = first.revision_id
+        for index in range(25):
+            revision = repository.append_revision(
+                _append(
+                    definition,
+                    statblock.statblock_id,
+                    parent,
+                    key=f"append-concurrent-{index}",
+                )
+            )
+            parent = revision.revision_id
+        stop.set()
+
+    def reader() -> None:
+        while not stop.is_set():
+            try:
+                current = repository.get(statblock.statblock_id)
+                repository.get_revision(statblock.statblock_id, current.latest_revision_id)
+                listed = repository.list_for_statblock(statblock.statblock_id)
+                assert any(
+                    item.revision_id == current.latest_revision_id for item in listed
+                )
+                repository.get_idempotency(
+                    "dungeonbuddy", "create_statblock", "create-1"
+                )
+            except BaseException as error:  # noqa: BLE001 - collect race failures
+                errors.append(error)
+                stop.set()
+                return
+
+    threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert errors == []
+    assert len(repository.list_for_statblock(statblock.statblock_id)) == 26


### PR DESCRIPTION
## Summary
- Rebases PR15 onto merged PR14/`main` and uses the final digest API (`compute_definition_digest(definition)` only).
- Create/append idempotency pins exact revision outcomes; append is CAS; transactional deadline/transport failures reconcile as indeterminate.
- Commands snapshot immutable intent and fix `request_digest` once; in-memory persistence locks all reads/writes; candidate create failures map to `PersistenceUnavailableError` (no `NameError`).
- Firestore keeps native timestamp TTL and has emulator-gated coverage plus unit seams for failure classification.

## Test plan
- [x] `./scripts/run_statblocks_v1_tests.sh` (110 passed, 4 emulator-gated skipped without host)
- [x] Candidate write deadline/general failure → `PersistenceUnavailableError`
- [x] Concurrent readers observe only committed latest/revision/list state
- [x] Mutating source definition/provenance/assets after command construction cannot diverge stored truth or digest