### PR TITLE
feat(statblocks_v1): PR16 structured outputs generation service

### DIFF
--- a/Docs/Design/DESIGN-dungeonbuddy-statblock-contract-v1.md
+++ b/Docs/Design/DESIGN-dungeonbuddy-statblock-contract-v1.md
@@ -206,6 +206,49 @@ GeneratedStatblockCandidateV1
   generation_receipt
   asset_brief
   assets
+  asset_warnings[]
+  created_at
+  expires_at
+  source_locator
+```
+
+`generation_receipt` is server-owned audit data:
+
+```text
+GenerationReceiptV1
+  request_id
+  provider
+  model
+  prompt_version
+  schema_version
+  schema_fingerprint
+  generated_at
+  caller_scope
+  actor
+  source_description_digest
+  source_definition_digest
+  source_locator
+  provider_request_id / provider_response_id
+  latency_ms / input_tokens / output_tokens
+```
+
+Ownership and provenance rules:
+
+- `caller_scope` / `actor` come from the authenticated request, never from model output.
+- `source_description_digest` digests authored prose (NFC + SHA-256). Callers may supply a
+  matching digest; a mismatch is rejected. It does not identify source mechanics.
+- `source_definition_digest` is required for every revision and is the PR14 digest of the
+  exact `StatblockDefinitionV1` embedded in the revision prompt (inline submission or
+  resolved immutable revision).
+- `source_locator` is present when revision used an exact `(statblock_id, revision_id)` read.
+- When `generate_images` is requested, `asset_brief` stores the exact effective brief passed
+  to the asset generator (authored description brief, or creature-name fallback).
+- `asset_warnings` are typed partial outcomes with stable codes, not free-form strings:
+
+```text
+AssetWarningV1
+  code: asset_generator_unconfigured | asset_generation_failed
+  message
 ```
 
 A candidate is not accepted mechanics truth. It may be edited, regenerated, rejected, or
@@ -915,9 +958,9 @@ The response is another candidate, not a persisted revision.
 
 ```json
 {
-  "contract": "dungeonmind.dungeonbuddy-statblocks",
-  "contract_version": "1.0.0",
-  "candidate_id": "candidate_...",
+  "contract": "dungeonbuddy-statblock",
+  "contract_version": "v1",
+  "candidate_id": "cand_...",
   "definition": {},
   "validation_receipt": {
     "status": "warnings",
@@ -925,16 +968,38 @@ The response is another candidate, not a persisted revision.
   },
   "generation_receipt": {
     "request_id": "req_...",
-    "generator_version": "...",
+    "provider": "openai",
     "model": "...",
-    "prompt_version": "...",
-    "created_at": "..."
+    "prompt_version": "statblock-generation-prompt-v1",
+    "schema_version": "...",
+    "schema_fingerprint": "...",
+    "generated_at": "...",
+    "caller_scope": "dungeonbuddy",
+    "actor": "optional-actor",
+    "source_description_digest": "sha256:...",
+    "source_definition_digest": "sha256:...",
+    "source_locator": {
+      "statblock_id": "sb_...",
+      "revision_id": "rev_..."
+    }
   },
   "asset_brief": {
     "prompt": "...",
     "recommended_roles": ["portrait", "token"]
   },
-  "assets": []
+  "assets": [],
+  "asset_warnings": [
+    {
+      "code": "asset_generator_unconfigured",
+      "message": "Asset generation was requested but no asset generator is configured."
+    }
+  ],
+  "created_at": "...",
+  "expires_at": "...",
+  "source_locator": {
+    "statblock_id": "sb_...",
+    "revision_id": "rev_..."
+  }
 }
 ```
 

--- a/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
+++ b/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
@@ -1,6 +1,6 @@
 # HANDOFF — PR16 Statblock v1 Structured Outputs generation service
 
-**Status:** IN REVIEW — four remaining trust-boundary blockers closed (digest provenance, key repurposing, fail-closed settings, typed assets) 
+**Status:** IN REVIEW — successor-facing gaps closed (pinned operation intent, design sync, Firestore typed round-trip) 
 **Target repository:** `Drakosfire/DungeonMindServer`  
 **Predecessors:** PR13 contract, PR14 trust core, PR15 repository protocols  
 **Successor:** `HANDOFF-pr17-statblock-v1-candidate-api.md`

--- a/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
+++ b/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
@@ -1,6 +1,6 @@
 # HANDOFF — PR16 Statblock v1 Structured Outputs generation service
 
-**Status:** IN REVIEW — rebased onto merged PR15; trust boundaries sealed  
+**Status:** IN REVIEW — four remaining trust-boundary blockers closed (digest provenance, key repurposing, fail-closed settings, typed assets) 
 **Target repository:** `Drakosfire/DungeonMindServer`  
 **Predecessors:** PR13 contract, PR14 trust core, PR15 repository protocols  
 **Successor:** `HANDOFF-pr17-statblock-v1-candidate-api.md`

--- a/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
+++ b/Docs/Plans/HANDOFF-pr16-statblock-v1-structured-generation-service.md
@@ -1,6 +1,6 @@
 # HANDOFF — PR16 Statblock v1 Structured Outputs generation service
 
-**Status:** READY AFTER PR14; INTEGRATES PR15  
+**Status:** IN REVIEW — rebased onto merged PR15; trust boundaries sealed  
 **Target repository:** `Drakosfire/DungeonMindServer`  
 **Predecessors:** PR13 contract, PR14 trust core, PR15 repository protocols  
 **Successor:** `HANDOFF-pr17-statblock-v1-candidate-api.md`

--- a/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
+++ b/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
@@ -37,17 +37,28 @@
   `definition_invalid`, `ruleset_mismatch`, `source_digest_mismatch`, and
   resolver codes (`revision_not_found`, `statblock_not_found`, `source_unavailable`)
   reserved for service-level failures.
-- Generation receipts store server-owned `caller_scope`/`actor` provenance and a
-  server-computed (optionally caller-verified) source description digest.
+- Generation receipts store server-owned `caller_scope`/`actor` provenance, a
+  server-computed (optionally caller-verified) source description digest, and for
+  every revision a PR14 `source_definition_digest` of the exact mechanics revised
+  (inline submitted definition or resolved locator revision). Description digests
+  never substitute for mechanics provenance.
   Warning-bearing candidate receipts may be persisted; invalid receipts are not.
-  `preserve_element_keys` is validated after revision (`ELEMENT_KEY_CHANGED` /
-  `ELEMENT_KEY_DROPPED` warnings). Requested image generation without a configured
-  asset generator yields an explicit asset warning.
+  `preserve_element_keys` is a versioned post-validation pass
+  (`validator_version` gains `+statblock-key-preservation-v1`) emitting
+  `ELEMENT_KEY_CHANGED`, `ELEMENT_KEY_DROPPED`, `ELEMENT_KEY_REPURPOSED`, and
+  `ELEMENT_KEY_IDENTITY_AMBIGUOUS`.
+  Asset partial outcomes use typed `AssetWarningV1` codes
+  (`asset_generator_unconfigured`, `asset_generation_failed`). When
+  `generate_images=True`, the exact effective `AssetBriefV1` passed to the
+  generator is always persisted on the candidate (name fallback when
+  `include_generation_brief=False`).
 - Settings are `STATBLOCKS_V1_OPENAI_MODEL`,
   `STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS`, `STATBLOCKS_V1_OPENAI_MAX_RETRIES`, and
-  `STATBLOCKS_V1_CANDIDATE_TTL_SECONDS`. The default model resolves the in-repo
-  `DungeonMindServer/MODEL_POLICY.json` action `structured_generation` (not a path
-  above the repository root); missing policy raises
+  `STATBLOCKS_V1_CANDIDATE_TTL_SECONDS`. Values are validated on the settings
+  model itself (non-empty model, finite timeout `> 0`, retries `>= 0`, TTL `> 0`);
+  malformed env input raises `InternalServiceMisconfiguredError`. The default
+  model resolves the in-repo `DungeonMindServer/MODEL_POLICY.json` action
+  `structured_generation`; missing policy raises
   `InternalServiceMisconfiguredError` unless the env override is set.
 - `FakeDefinitionProvider` accepts a JSON payload or `ProviderOutcomeV1` and records
   calls. It supports offline route tests; `candidate_id_factory` and clock make

--- a/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
+++ b/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
@@ -25,6 +25,10 @@
   `GeneratedStatblockCandidateV1` or `GenerationFailureV1`; routes must map the latter
   without exposing provider exceptions (provider exceptions are caught at the service
   boundary as `provider_failure`).
+- The service deep-copies and pins operation intent before the provider call (prompt,
+  digests, ruleset, caller, locator, source definition, asset options). Concurrent
+  mutation of the caller's command after entry cannot change receipt provenance or
+  key-preservation inputs. Treat commands as write-once at the route boundary.
 - Construct the service through dependency injection with a `DefinitionProvider`,
   `CandidateRepository`, `GenerationSettingsV1`, clock, candidate-ID factory, and,
   for revision locators, `PersistenceDefinitionResolver` over

--- a/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
+++ b/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
@@ -23,18 +23,32 @@
 - Application entry points are `GenerationServiceV1.generate(GenerateStatblockCommandV1)`
   and `GenerationServiceV1.revise(ReviseStatblockCommandV1)`. Both return either
   `GeneratedStatblockCandidateV1` or `GenerationFailureV1`; routes must map the latter
-  without exposing provider exceptions.
+  without exposing provider exceptions (provider exceptions are caught at the service
+  boundary as `provider_failure`).
 - Construct the service through dependency injection with a `DefinitionProvider`,
   `CandidateRepository`, `GenerationSettingsV1`, clock, candidate-ID factory, and,
-  for revision locators, a definition resolver. Tests use `FakeDefinitionProvider`
-  plus `InMemoryCandidateRepository`.
+  for revision locators, `PersistenceDefinitionResolver` over
+  `StatblockPersistenceRepository.get_revision(statblock_id, revision_id)`.
+  Revision commands use `ExactRevisionLocatorV1(statblock_id, revision_id)`, not a
+  single-id `ResourceLocatorV1`. Tests use `FakeDefinitionProvider` plus
+  `InMemoryCandidateRepository`.
 - Provider outcomes are `success`, `refusal`, `incomplete`, `timeout`, `rate_limit`,
   and `failure`; application failures are prefixed `provider_`, with
-  `definition_invalid` reserved for parsing/semantic validation failures.
+  `definition_invalid`, `ruleset_mismatch`, `source_digest_mismatch`, and
+  resolver codes (`revision_not_found`, `statblock_not_found`, `source_unavailable`)
+  reserved for service-level failures.
+- Generation receipts store server-owned `caller_scope`/`actor` provenance and a
+  server-computed (optionally caller-verified) source description digest.
+  Warning-bearing candidate receipts may be persisted; invalid receipts are not.
+  `preserve_element_keys` is validated after revision (`ELEMENT_KEY_CHANGED` /
+  `ELEMENT_KEY_DROPPED` warnings). Requested image generation without a configured
+  asset generator yields an explicit asset warning.
 - Settings are `STATBLOCKS_V1_OPENAI_MODEL`,
   `STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS`, `STATBLOCKS_V1_OPENAI_MAX_RETRIES`, and
-  `STATBLOCKS_V1_CANDIDATE_TTL_SECONDS`. The default model resolves
-  `MODEL_POLICY.json` action `structured_generation`, not a raw model ID.
+  `STATBLOCKS_V1_CANDIDATE_TTL_SECONDS`. The default model resolves the in-repo
+  `DungeonMindServer/MODEL_POLICY.json` action `structured_generation` (not a path
+  above the repository root); missing policy raises
+  `InternalServiceMisconfiguredError` unless the env override is set.
 - `FakeDefinitionProvider` accepts a JSON payload or `ProviderOutcomeV1` and records
   calls. It supports offline route tests; `candidate_id_factory` and clock make
   receipts/candidate expiry deterministic.

--- a/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
+++ b/Docs/Plans/HANDOFF-pr17-statblock-v1-candidate-api.md
@@ -18,6 +18,27 @@
 - Reuse `compute_request_digest(operation, payload)` for request replay: it includes
   operation parameters rather than using only the mechanics definition digest.
 
+## PR16 predecessor completion notes
+
+- Application entry points are `GenerationServiceV1.generate(GenerateStatblockCommandV1)`
+  and `GenerationServiceV1.revise(ReviseStatblockCommandV1)`. Both return either
+  `GeneratedStatblockCandidateV1` or `GenerationFailureV1`; routes must map the latter
+  without exposing provider exceptions.
+- Construct the service through dependency injection with a `DefinitionProvider`,
+  `CandidateRepository`, `GenerationSettingsV1`, clock, candidate-ID factory, and,
+  for revision locators, a definition resolver. Tests use `FakeDefinitionProvider`
+  plus `InMemoryCandidateRepository`.
+- Provider outcomes are `success`, `refusal`, `incomplete`, `timeout`, `rate_limit`,
+  and `failure`; application failures are prefixed `provider_`, with
+  `definition_invalid` reserved for parsing/semantic validation failures.
+- Settings are `STATBLOCKS_V1_OPENAI_MODEL`,
+  `STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS`, `STATBLOCKS_V1_OPENAI_MAX_RETRIES`, and
+  `STATBLOCKS_V1_CANDIDATE_TTL_SECONDS`. The default model resolves
+  `MODEL_POLICY.json` action `structured_generation`, not a raw model ID.
+- `FakeDefinitionProvider` accepts a JSON payload or `ProviderOutcomeV1` and records
+  calls. It supports offline route tests; `candidate_id_factory` and clock make
+  receipts/candidate expiry deterministic.
+
 ## 0. Mission
 
 Expose the generation, revision, validation, and candidate-read operations through the dedicated authenticated DungeonBuddy v1 router.

--- a/MODEL_POLICY.json
+++ b/MODEL_POLICY.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "models": {
+    "highest_intelligence": "gpt-5.4",
+    "fast_smart": "gpt-5.3-codex",
+    "fast_smart_mini": "gpt-5.4-mini",
+    "cheapest": "gpt-5.4-nano",
+    "retrieval_synthesis": "gpt-5.3-chat-latest"
+  },
+  "actions": {
+    "default_text_generation": "fast_smart",
+    "structured_generation": "cheapest",
+    "map_prompt_compilation": "fast_smart",
+    "svg_mask_generation": "fast_smart",
+    "player_character_generation": "fast_smart",
+    "ruleslawyer_response_synthesis": "retrieval_synthesis",
+    "query_planning": "cheapest",
+    "architecture_and_complex_reasoning": "highest_intelligence",
+    "wiki_compile": "cheapest",
+    "corpus_session_planner": "fast_smart_mini",
+    "live_turn_classifier": "cheapest",
+    "npc_intent_classifier": "cheapest",
+    "graph_memory_category_extraction": "fast_smart_mini",
+    "hermes_graph_agent": "fast_smart_mini"
+  },
+  "notes": {
+    "policy": "Prefer the smallest model that reliably does the job. Escalate to gpt-5.4 only when the task truly needs maximum reasoning quality.",
+    "deprecated_defaults": [
+      "gpt-5.1"
+    ]
+  }
+}

--- a/statblocks_v1/application/commands.py
+++ b/statblocks_v1/application/commands.py
@@ -5,7 +5,7 @@ from pydantic import Field, model_validator
 
 from statblocks_v1.domain.primitives import StrictModel
 from statblocks_v1.domain.profiles import RulesetRef
-from statblocks_v1.domain.resources import ResourceLocatorV1
+from statblocks_v1.domain.resources import ExactRevisionLocatorV1
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 
 
@@ -55,7 +55,7 @@ class ReviseStatblockCommandV1(StrictModel):
     revision_instructions: list[str] = Field(min_length=1)
     caller: CallerProvenanceV1
     source_definition: StatblockDefinitionV1 | None = None
-    source_locator: ResourceLocatorV1 | None = None
+    source_locator: ExactRevisionLocatorV1 | None = None
     source: SourceSnapshotV1 | None = None
     intent: GenerationIntentV1 = Field(default_factory=GenerationIntentV1)
     context: EncounterContextV1 = Field(default_factory=EncounterContextV1)

--- a/statblocks_v1/application/commands.py
+++ b/statblocks_v1/application/commands.py
@@ -1,0 +1,74 @@
+"""Transport-neutral commands for statblock candidate generation."""
+from __future__ import annotations
+
+from pydantic import Field, model_validator
+
+from statblocks_v1.domain.primitives import StrictModel
+from statblocks_v1.domain.profiles import RulesetRef
+from statblocks_v1.domain.resources import ResourceLocatorV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+
+class SourceSnapshotV1(StrictModel):
+    name_hint: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    description_digest: str | None = Field(default=None, pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+class GenerationIntentV1(StrictModel):
+    target_cr: str | None = None
+    roles: list[str] = Field(default_factory=list)
+    complexity: str | None = None
+    must_include: list[str] = Field(default_factory=list)
+    must_avoid: list[str] = Field(default_factory=list)
+
+
+class EncounterContextV1(StrictModel):
+    party_level: int | None = Field(default=None, ge=1)
+    party_size: int | None = Field(default=None, ge=1)
+    terrain_notes: list[str] = Field(default_factory=list)
+
+
+class AssetOptionsV1(StrictModel):
+    include_generation_brief: bool = True
+    generate_images: bool = False
+
+
+class CallerProvenanceV1(StrictModel):
+    caller_scope: str = Field(min_length=1)
+    actor: str | None = None
+
+
+class GenerateStatblockCommandV1(StrictModel):
+    request_id: str = Field(min_length=1)
+    ruleset: RulesetRef
+    source: SourceSnapshotV1
+    intent: GenerationIntentV1 = Field(default_factory=GenerationIntentV1)
+    context: EncounterContextV1 = Field(default_factory=EncounterContextV1)
+    asset_options: AssetOptionsV1 = Field(default_factory=AssetOptionsV1)
+    caller: CallerProvenanceV1
+
+
+class ReviseStatblockCommandV1(StrictModel):
+    request_id: str = Field(min_length=1)
+    ruleset: RulesetRef
+    revision_instructions: list[str] = Field(min_length=1)
+    caller: CallerProvenanceV1
+    source_definition: StatblockDefinitionV1 | None = None
+    source_locator: ResourceLocatorV1 | None = None
+    source: SourceSnapshotV1 | None = None
+    intent: GenerationIntentV1 = Field(default_factory=GenerationIntentV1)
+    context: EncounterContextV1 = Field(default_factory=EncounterContextV1)
+    asset_options: AssetOptionsV1 = Field(default_factory=AssetOptionsV1)
+    preserve_element_keys: bool = True
+
+    @model_validator(mode="after")
+    def has_exactly_one_source(self) -> "ReviseStatblockCommandV1":
+        if (self.source_definition is None) == (self.source_locator is None):
+            raise ValueError("provide exactly one of source_definition or source_locator")
+        return self
+
+
+class AssetBriefV1(StrictModel):
+    prompt: str = Field(min_length=1)
+    recommended_roles: list[str] = Field(default_factory=lambda: ["portrait", "token"])

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -1,0 +1,190 @@
+"""Application service for generation and revision candidate workflows."""
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+from pydantic import ValidationError
+
+from statblocks_v1.application.commands import (
+    AssetBriefV1,
+    GenerateStatblockCommandV1,
+    ReviseStatblockCommandV1,
+)
+from statblocks_v1.application.prompts import build_generation_prompt, build_revision_prompt
+from statblocks_v1.application.provider import (
+    DefinitionProvider,
+    ProviderOptionsV1,
+    ProviderOutcomeKind,
+)
+from statblocks_v1.application.schema_compiler import compile_openai_definition_schema
+from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.application.repositories import CandidateRepository
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
+    GenerationReceiptV1,
+    ResourceLocatorV1,
+)
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.validation import validate_definition
+
+Clock = Callable[[], datetime]
+CandidateIdFactory = Callable[[], str]
+
+
+class DefinitionResolver(Protocol):
+    def resolve(self, locator: ResourceLocatorV1) -> StatblockDefinitionV1: ...
+
+
+class AssetGenerator(Protocol):
+    def generate(self, brief: AssetBriefV1) -> list[dict[str, object]]: ...
+
+
+@dataclass(frozen=True)
+class GenerationFailureV1:
+    kind: str
+    message: str
+
+
+GenerationResultV1 = GeneratedStatblockCandidateV1 | GenerationFailureV1
+
+
+class GenerationServiceV1:
+    """Coordinates provider output without letting provider metadata enter the definition."""
+
+    def __init__(
+        self,
+        *,
+        provider: DefinitionProvider,
+        candidates: CandidateRepository,
+        settings: GenerationSettingsV1,
+        clock: Clock | None = None,
+        candidate_id_factory: CandidateIdFactory | None = None,
+        definition_resolver: DefinitionResolver | None = None,
+        asset_generator: AssetGenerator | None = None,
+    ) -> None:
+        self._provider = provider
+        self._candidates = candidates
+        self._settings = settings
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._candidate_id_factory = candidate_id_factory or _new_candidate_id
+        self._definition_resolver = definition_resolver
+        self._asset_generator = asset_generator
+
+    def generate(self, command: GenerateStatblockCommandV1) -> GenerationResultV1:
+        return self._run(
+            request_id=command.request_id,
+            prompt=build_generation_prompt(command),
+            source_digest=command.source.description_digest or _digest_text(command.source.description),
+            source_locator=None,
+            asset_prompt=command.source.description if command.asset_options.include_generation_brief else None,
+            generate_assets=command.asset_options.generate_images,
+        )
+
+    def revise(self, command: ReviseStatblockCommandV1) -> GenerationResultV1:
+        source = command.source_definition
+        if source is None:
+            if self._definition_resolver is None:
+                return GenerationFailureV1("source_unavailable", "No definition resolver is configured")
+            source = self._definition_resolver.resolve(command.source_locator)  # type: ignore[arg-type]
+        return self._run(
+            request_id=command.request_id,
+            prompt=build_revision_prompt(command, source),
+            source_digest=(command.source.description_digest if command.source else None),
+            source_locator=command.source_locator,
+            asset_prompt=(command.source.description if command.source and command.asset_options.include_generation_brief else None),
+            generate_assets=command.asset_options.generate_images,
+        )
+
+    def _run(
+        self,
+        *,
+        request_id: str,
+        prompt: str,
+        source_digest: str | None,
+        source_locator: ResourceLocatorV1 | None,
+        asset_prompt: str | None,
+        generate_assets: bool,
+    ) -> GenerationResultV1:
+        compiled = compile_openai_definition_schema()
+        started = time.monotonic()
+        outcome = self._provider.generate_definition(
+            prompt=prompt,
+            schema=compiled,
+            options=ProviderOptionsV1(
+                model=self._settings.model,
+                timeout_seconds=self._settings.timeout_seconds,
+                max_retries=self._settings.max_retries,
+            ),
+        )
+        if outcome.kind is not ProviderOutcomeKind.success:
+            return GenerationFailureV1(f"provider_{outcome.kind.value}", outcome.message or "Provider did not return a definition")
+        try:
+            definition = StatblockDefinitionV1.model_validate(outcome.payload)
+        except ValidationError:
+            return GenerationFailureV1("definition_invalid", "Provider output does not match StatblockDefinitionV1")
+        now = self._clock()
+        receipt = validate_definition(
+            definition, ValidationMode.generation_candidate, validated_at=now
+        )
+        if not receipt.is_persistence_ready:
+            return GenerationFailureV1("definition_invalid", "Provider output has structural or reference errors")
+        candidate = GeneratedStatblockCandidateV1(
+            candidate_id=self._candidate_id_factory(),
+            definition=definition,
+            validation_receipt=receipt,
+            generation_receipt=GenerationReceiptV1(
+                request_id=request_id,
+                provider=self._provider.provider_name,
+                model=self._settings.model,
+                prompt_version="statblock-generation-prompt-v1",
+                schema_version=compiled.compiler_version,
+                schema_fingerprint=compiled.fingerprint,
+                generated_at=now,
+                source_description_digest=source_digest,
+                source_locator=source_locator,
+                provider_request_id=outcome.request_id,
+                provider_response_id=outcome.response_id,
+                latency_ms=outcome.latency_ms or int((time.monotonic() - started) * 1000),
+                input_tokens=outcome.input_tokens,
+                output_tokens=outcome.output_tokens,
+            ),
+            asset_brief=AssetBriefV1(prompt=asset_prompt).model_dump(mode="json") if asset_prompt else None,
+            assets=[],
+            asset_warnings=[],
+            created_at=now,
+            expires_at=now + timedelta(seconds=self._settings.candidate_ttl_seconds),
+            source_locator=source_locator,
+        )
+        if asset_prompt and generate_assets and self._asset_generator is not None:
+            try:
+                assets = self._asset_generator.generate(AssetBriefV1(prompt=asset_prompt))
+                candidate = candidate.model_copy(update={"assets": assets})
+            except Exception:
+                candidate = candidate.model_copy(
+                    update={"asset_warnings": ["Asset generation failed; review the candidate without assets."]}
+                )
+        return self._candidates.create(candidate)
+
+
+def _digest_text(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _new_candidate_id() -> str:
+    return f"cand_{_base36(secrets.randbelow(36**16))}"
+
+
+def _base36(value: int) -> str:
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+    result = "0"
+    while value:
+        value, remainder = divmod(value, 36)
+        result = alphabet[remainder] + result.lstrip("0")
+    return result

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 import time
+import unicodedata
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -13,23 +14,33 @@ from pydantic import ValidationError
 
 from statblocks_v1.application.commands import (
     AssetBriefV1,
+    CallerProvenanceV1,
     GenerateStatblockCommandV1,
     ReviseStatblockCommandV1,
+    SourceSnapshotV1,
 )
-from statblocks_v1.application.prompts import build_generation_prompt, build_revision_prompt
+from statblocks_v1.application.prompts import PROMPT_VERSION, build_generation_prompt, build_revision_prompt
 from statblocks_v1.application.provider import (
     DefinitionProvider,
     ProviderOptionsV1,
     ProviderOutcomeKind,
 )
+from statblocks_v1.application.repositories import CandidateRepository
 from statblocks_v1.application.schema_compiler import compile_openai_definition_schema
 from statblocks_v1.application.settings import GenerationSettingsV1
-from statblocks_v1.application.repositories import CandidateRepository
-from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.errors import StatblockV1Error
+from statblocks_v1.domain.profiles import RulesetRef
+from statblocks_v1.domain.receipts import (
+    ValidationIssueV1,
+    ValidationMode,
+    ValidationReceiptV1,
+    ValidationSeverity,
+    ValidationStatus,
+)
 from statblocks_v1.domain.resources import (
+    ExactRevisionLocatorV1,
     GeneratedStatblockCandidateV1,
     GenerationReceiptV1,
-    ResourceLocatorV1,
 )
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
@@ -39,7 +50,7 @@ CandidateIdFactory = Callable[[], str]
 
 
 class DefinitionResolver(Protocol):
-    def resolve(self, locator: ResourceLocatorV1) -> StatblockDefinitionV1: ...
+    def resolve(self, locator: ExactRevisionLocatorV1) -> StatblockDefinitionV1: ...
 
 
 class AssetGenerator(Protocol):
@@ -78,27 +89,65 @@ class GenerationServiceV1:
         self._asset_generator = asset_generator
 
     def generate(self, command: GenerateStatblockCommandV1) -> GenerationResultV1:
+        digest_error = _verified_source_digest(command.source)
+        if isinstance(digest_error, GenerationFailureV1):
+            return digest_error
+        source_digest = digest_error
         return self._run(
             request_id=command.request_id,
+            ruleset=command.ruleset,
+            caller=command.caller,
             prompt=build_generation_prompt(command),
-            source_digest=command.source.description_digest or _digest_text(command.source.description),
+            source_digest=source_digest,
             source_locator=None,
-            asset_prompt=command.source.description if command.asset_options.include_generation_brief else None,
+            source_definition=None,
+            preserve_element_keys=False,
+            asset_prompt=(
+                command.source.description if command.asset_options.include_generation_brief else None
+            ),
             generate_assets=command.asset_options.generate_images,
         )
 
     def revise(self, command: ReviseStatblockCommandV1) -> GenerationResultV1:
         source = command.source_definition
+        source_locator = command.source_locator
         if source is None:
+            if source_locator is None:
+                return GenerationFailureV1("invalid_request", "Revision source is missing")
             if self._definition_resolver is None:
-                return GenerationFailureV1("source_unavailable", "No definition resolver is configured")
-            source = self._definition_resolver.resolve(command.source_locator)  # type: ignore[arg-type]
+                return GenerationFailureV1(
+                    "source_unavailable", "No definition resolver is configured"
+                )
+            try:
+                source = self._definition_resolver.resolve(source_locator)
+            except StatblockV1Error as error:
+                return GenerationFailureV1(error.code, error.message)
+            except Exception:
+                return GenerationFailureV1(
+                    "source_unavailable", "Failed to resolve source revision"
+                )
+
+        source_digest: str | None = None
+        if command.source is not None:
+            digest_error = _verified_source_digest(command.source)
+            if isinstance(digest_error, GenerationFailureV1):
+                return digest_error
+            source_digest = digest_error
+
         return self._run(
             request_id=command.request_id,
+            ruleset=command.ruleset,
+            caller=command.caller,
             prompt=build_revision_prompt(command, source),
-            source_digest=(command.source.description_digest if command.source else None),
-            source_locator=command.source_locator,
-            asset_prompt=(command.source.description if command.source and command.asset_options.include_generation_brief else None),
+            source_digest=source_digest,
+            source_locator=source_locator,
+            source_definition=source,
+            preserve_element_keys=command.preserve_element_keys,
+            asset_prompt=(
+                command.source.description
+                if command.source and command.asset_options.include_generation_brief
+                else None
+            ),
             generate_assets=command.asset_options.generate_images,
         )
 
@@ -106,35 +155,79 @@ class GenerationServiceV1:
         self,
         *,
         request_id: str,
+        ruleset: RulesetRef,
+        caller: CallerProvenanceV1,
         prompt: str,
         source_digest: str | None,
-        source_locator: ResourceLocatorV1 | None,
+        source_locator: ExactRevisionLocatorV1 | None,
+        source_definition: StatblockDefinitionV1 | None,
+        preserve_element_keys: bool,
         asset_prompt: str | None,
         generate_assets: bool,
     ) -> GenerationResultV1:
         compiled = compile_openai_definition_schema()
         started = time.monotonic()
-        outcome = self._provider.generate_definition(
-            prompt=prompt,
-            schema=compiled,
-            options=ProviderOptionsV1(
-                model=self._settings.model,
-                timeout_seconds=self._settings.timeout_seconds,
-                max_retries=self._settings.max_retries,
-            ),
-        )
+        try:
+            outcome = self._provider.generate_definition(
+                prompt=prompt,
+                schema=compiled,
+                options=ProviderOptionsV1(
+                    model=self._settings.model,
+                    timeout_seconds=self._settings.timeout_seconds,
+                    max_retries=self._settings.max_retries,
+                ),
+            )
+        except Exception:
+            return GenerationFailureV1(
+                "provider_failure", "Provider raised an unexpected error"
+            )
         if outcome.kind is not ProviderOutcomeKind.success:
-            return GenerationFailureV1(f"provider_{outcome.kind.value}", outcome.message or "Provider did not return a definition")
+            return GenerationFailureV1(
+                f"provider_{outcome.kind.value}",
+                outcome.message or "Provider did not return a definition",
+            )
+        if outcome.payload is None:
+            return GenerationFailureV1(
+                "provider_incomplete", "Provider returned no definition payload"
+            )
         try:
             definition = StatblockDefinitionV1.model_validate(outcome.payload)
         except ValidationError:
-            return GenerationFailureV1("definition_invalid", "Provider output does not match StatblockDefinitionV1")
+            return GenerationFailureV1(
+                "definition_invalid", "Provider output does not match StatblockDefinitionV1"
+            )
+        if not _ruleset_matches(definition.ruleset, ruleset):
+            return GenerationFailureV1(
+                "ruleset_mismatch",
+                "Generated definition ruleset does not match the requested ruleset",
+            )
+
         now = self._clock()
         receipt = validate_definition(
             definition, ValidationMode.generation_candidate, validated_at=now
         )
-        if not receipt.is_persistence_ready:
-            return GenerationFailureV1("definition_invalid", "Provider output has structural or reference errors")
+        if receipt.status is ValidationStatus.invalid:
+            return GenerationFailureV1(
+                "definition_invalid", "Provider output has structural or reference errors"
+            )
+        if source_definition is not None and preserve_element_keys:
+            receipt = _with_key_preservation_warnings(receipt, source_definition, definition)
+
+        asset_warnings: list[str] = []
+        assets: list[dict[str, object]] = []
+        if generate_assets:
+            if self._asset_generator is None:
+                asset_warnings.append(
+                    "Asset generation was requested but no asset generator is configured."
+                )
+            else:
+                try:
+                    assets = self._asset_generator.generate(AssetBriefV1(prompt=asset_prompt or definition.identity.name))
+                except Exception:
+                    asset_warnings.append(
+                        "Asset generation failed; review the candidate without assets."
+                    )
+
         candidate = GeneratedStatblockCandidateV1(
             candidate_id=self._candidate_id_factory(),
             definition=definition,
@@ -143,10 +236,12 @@ class GenerationServiceV1:
                 request_id=request_id,
                 provider=self._provider.provider_name,
                 model=self._settings.model,
-                prompt_version="statblock-generation-prompt-v1",
+                prompt_version=PROMPT_VERSION,
                 schema_version=compiled.compiler_version,
                 schema_fingerprint=compiled.fingerprint,
                 generated_at=now,
+                caller_scope=caller.caller_scope,
+                actor=caller.actor,
                 source_description_digest=source_digest,
                 source_locator=source_locator,
                 provider_request_id=outcome.request_id,
@@ -156,25 +251,93 @@ class GenerationServiceV1:
                 output_tokens=outcome.output_tokens,
             ),
             asset_brief=AssetBriefV1(prompt=asset_prompt).model_dump(mode="json") if asset_prompt else None,
-            assets=[],
-            asset_warnings=[],
+            assets=assets,
+            asset_warnings=asset_warnings,
             created_at=now,
             expires_at=now + timedelta(seconds=self._settings.candidate_ttl_seconds),
             source_locator=source_locator,
         )
-        if asset_prompt and generate_assets and self._asset_generator is not None:
-            try:
-                assets = self._asset_generator.generate(AssetBriefV1(prompt=asset_prompt))
-                candidate = candidate.model_copy(update={"assets": assets})
-            except Exception:
-                candidate = candidate.model_copy(
-                    update={"asset_warnings": ["Asset generation failed; review the candidate without assets."]}
-                )
         return self._candidates.create(candidate)
 
 
+def _verified_source_digest(source: SourceSnapshotV1) -> str | GenerationFailureV1:
+    computed = _digest_text(source.description)
+    if source.description_digest is not None and source.description_digest != computed:
+        return GenerationFailureV1(
+            "source_digest_mismatch",
+            "Caller-supplied source description digest does not match the description",
+        )
+    return computed
+
+
+def _ruleset_matches(actual: RulesetRef, requested: RulesetRef) -> bool:
+    return (
+        actual.system == requested.system
+        and actual.edition == requested.edition
+        and actual.house_ruleset_id == requested.house_ruleset_id
+    )
+
+
+def _with_key_preservation_warnings(
+    receipt: ValidationReceiptV1,
+    source: StatblockDefinitionV1,
+    revised: StatblockDefinitionV1,
+) -> ValidationReceiptV1:
+    issues = list(receipt.issues)
+    revised_by_identity = {
+        (_element_identity(element.section.value, element.name)): element
+        for element in revised.rule_elements
+    }
+    revised_keys = {element.key for element in revised.rule_elements}
+    for index, element in enumerate(source.rule_elements):
+        identity = _element_identity(element.section.value, element.name)
+        match = revised_by_identity.get(identity)
+        if match is None:
+            if element.key not in revised_keys:
+                issues.append(
+                    ValidationIssueV1(
+                        code="ELEMENT_KEY_DROPPED",
+                        severity=ValidationSeverity.warning,
+                        field_path=f"rule_elements[{index}].key",
+                        message=(
+                            f"Source element key '{element.key}' was not preserved; "
+                            "confirm the conceptual rule was intentionally replaced."
+                        ),
+                    )
+                )
+            continue
+        if match.key != element.key:
+            revised_index = next(
+                i for i, item in enumerate(revised.rule_elements) if item.key == match.key
+            )
+            issues.append(
+                ValidationIssueV1(
+                    code="ELEMENT_KEY_CHANGED",
+                    severity=ValidationSeverity.warning,
+                    field_path=f"rule_elements[{revised_index}].key",
+                    message=(
+                        f"Element '{element.name}' changed key from '{element.key}' "
+                        f"to '{match.key}' despite preserve_element_keys."
+                    ),
+                )
+            )
+    status = (
+        ValidationStatus.invalid
+        if any(issue.severity is ValidationSeverity.error for issue in issues)
+        else ValidationStatus.warnings
+        if issues
+        else ValidationStatus.valid
+    )
+    return receipt.model_copy(update={"issues": issues, "status": status})
+
+
+def _element_identity(section: str, name: str) -> tuple[str, str]:
+    return (section, unicodedata.normalize("NFC", name).casefold())
+
+
 def _digest_text(value: str) -> str:
-    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+    normalized = unicodedata.normalize("NFC", value)
+    return f"sha256:{hashlib.sha256(normalized.encode('utf-8')).hexdigest()}"
 
 
 def _new_candidate_id() -> str:

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -5,6 +5,7 @@ import hashlib
 import secrets
 import time
 import unicodedata
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -28,6 +29,7 @@ from statblocks_v1.application.provider import (
 from statblocks_v1.application.repositories import CandidateRepository
 from statblocks_v1.application.schema_compiler import compile_openai_definition_schema
 from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import StatblockV1Error
 from statblocks_v1.domain.profiles import RulesetRef
 from statblocks_v1.domain.receipts import (
@@ -38,15 +40,19 @@ from statblocks_v1.domain.receipts import (
     ValidationStatus,
 )
 from statblocks_v1.domain.resources import (
+    AssetWarningCode,
+    AssetWarningV1,
     ExactRevisionLocatorV1,
     GeneratedStatblockCandidateV1,
     GenerationReceiptV1,
 )
-from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.rule_elements import RuleElement, StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
 
 Clock = Callable[[], datetime]
 CandidateIdFactory = Callable[[], str]
+
+KEY_PRESERVATION_PASS_VERSION = "statblock-key-preservation-v1"
 
 
 class DefinitionResolver(Protocol):
@@ -99,6 +105,7 @@ class GenerationServiceV1:
             caller=command.caller,
             prompt=build_generation_prompt(command),
             source_digest=source_digest,
+            source_definition_digest=None,
             source_locator=None,
             source_definition=None,
             preserve_element_keys=False,
@@ -106,6 +113,7 @@ class GenerationServiceV1:
                 command.source.description if command.asset_options.include_generation_brief else None
             ),
             generate_assets=command.asset_options.generate_images,
+            include_generation_brief=command.asset_options.include_generation_brief,
         )
 
     def revise(self, command: ReviseStatblockCommandV1) -> GenerationResultV1:
@@ -140,6 +148,7 @@ class GenerationServiceV1:
             caller=command.caller,
             prompt=build_revision_prompt(command, source),
             source_digest=source_digest,
+            source_definition_digest=compute_definition_digest(source),
             source_locator=source_locator,
             source_definition=source,
             preserve_element_keys=command.preserve_element_keys,
@@ -149,6 +158,7 @@ class GenerationServiceV1:
                 else None
             ),
             generate_assets=command.asset_options.generate_images,
+            include_generation_brief=command.asset_options.include_generation_brief,
         )
 
     def _run(
@@ -159,11 +169,13 @@ class GenerationServiceV1:
         caller: CallerProvenanceV1,
         prompt: str,
         source_digest: str | None,
+        source_definition_digest: str | None,
         source_locator: ExactRevisionLocatorV1 | None,
         source_definition: StatblockDefinitionV1 | None,
         preserve_element_keys: bool,
         asset_prompt: str | None,
         generate_assets: bool,
+        include_generation_brief: bool,
     ) -> GenerationResultV1:
         compiled = compile_openai_definition_schema()
         started = time.monotonic()
@@ -213,20 +225,40 @@ class GenerationServiceV1:
         if source_definition is not None and preserve_element_keys:
             receipt = _with_key_preservation_warnings(receipt, source_definition, definition)
 
-        asset_warnings: list[str] = []
+        asset_warnings: list[AssetWarningV1] = []
         assets: list[dict[str, object]] = []
+        asset_brief_model: AssetBriefV1 | None = None
         if generate_assets:
+            # When images are requested, always persist the exact brief used.
+            # Without an authored description brief, fall back to the creature name.
+            effective_prompt = asset_prompt or definition.identity.name
+            asset_brief_model = AssetBriefV1(prompt=effective_prompt)
             if self._asset_generator is None:
                 asset_warnings.append(
-                    "Asset generation was requested but no asset generator is configured."
+                    AssetWarningV1(
+                        code=AssetWarningCode.asset_generator_unconfigured,
+                        message=(
+                            "Asset generation was requested but no asset generator is configured."
+                        ),
+                    )
                 )
             else:
                 try:
-                    assets = self._asset_generator.generate(AssetBriefV1(prompt=asset_prompt or definition.identity.name))
+                    assets = self._asset_generator.generate(asset_brief_model)
                 except Exception:
                     asset_warnings.append(
-                        "Asset generation failed; review the candidate without assets."
+                        AssetWarningV1(
+                            code=AssetWarningCode.asset_generation_failed,
+                            message="Asset generation failed; review the candidate without assets.",
+                        )
                     )
+        elif include_generation_brief and asset_prompt is not None:
+            asset_brief_model = AssetBriefV1(prompt=asset_prompt)
+
+        measured_latency_ms = int((time.monotonic() - started) * 1000)
+        latency_ms = (
+            outcome.latency_ms if outcome.latency_ms is not None else measured_latency_ms
+        )
 
         candidate = GeneratedStatblockCandidateV1(
             candidate_id=self._candidate_id_factory(),
@@ -243,14 +275,17 @@ class GenerationServiceV1:
                 caller_scope=caller.caller_scope,
                 actor=caller.actor,
                 source_description_digest=source_digest,
+                source_definition_digest=source_definition_digest,
                 source_locator=source_locator,
                 provider_request_id=outcome.request_id,
                 provider_response_id=outcome.response_id,
-                latency_ms=outcome.latency_ms or int((time.monotonic() - started) * 1000),
+                latency_ms=latency_ms,
                 input_tokens=outcome.input_tokens,
                 output_tokens=outcome.output_tokens,
             ),
-            asset_brief=AssetBriefV1(prompt=asset_prompt).model_dump(mode="json") if asset_prompt else None,
+            asset_brief=(
+                asset_brief_model.model_dump(mode="json") if asset_brief_model is not None else None
+            ),
             assets=assets,
             asset_warnings=asset_warnings,
             created_at=now,
@@ -284,43 +319,88 @@ def _with_key_preservation_warnings(
     revised: StatblockDefinitionV1,
 ) -> ValidationReceiptV1:
     issues = list(receipt.issues)
-    revised_by_identity = {
-        (_element_identity(element.section.value, element.name)): element
-        for element in revised.rule_elements
+    source_by_identity = _group_by_identity(source.rule_elements)
+    revised_by_identity = _group_by_identity(revised.rule_elements)
+    revised_by_key = {
+        element.key: (index, element)
+        for index, element in enumerate(revised.rule_elements)
     }
-    revised_keys = {element.key for element in revised.rule_elements}
+    ambiguous_identities = {
+        identity
+        for identity, items in source_by_identity.items()
+        if len(items) > 1
+    } | {
+        identity
+        for identity, items in revised_by_identity.items()
+        if len(items) > 1
+    }
+
     for index, element in enumerate(source.rule_elements):
         identity = _element_identity(element.section.value, element.name)
-        match = revised_by_identity.get(identity)
-        if match is None:
-            if element.key not in revised_keys:
+        if identity in ambiguous_identities:
+            issues.append(
+                ValidationIssueV1(
+                    code="ELEMENT_KEY_IDENTITY_AMBIGUOUS",
+                    severity=ValidationSeverity.warning,
+                    field_path=f"rule_elements[{index}].name",
+                    message=(
+                        f"Element '{element.name}' in section '{element.section.value}' "
+                        "is not uniquely identifiable for key-preservation matching."
+                    ),
+                )
+            )
+            continue
+
+        revised_matches = revised_by_identity.get(identity, [])
+        if revised_matches:
+            revised_index, match = revised_matches[0]
+            if match.key != element.key:
                 issues.append(
                     ValidationIssueV1(
-                        code="ELEMENT_KEY_DROPPED",
+                        code="ELEMENT_KEY_CHANGED",
                         severity=ValidationSeverity.warning,
-                        field_path=f"rule_elements[{index}].key",
+                        field_path=f"rule_elements[{revised_index}].key",
                         message=(
-                            f"Source element key '{element.key}' was not preserved; "
-                            "confirm the conceptual rule was intentionally replaced."
+                            f"Element '{element.name}' changed key from '{element.key}' "
+                            f"to '{match.key}' despite preserve_element_keys."
                         ),
                     )
                 )
             continue
-        if match.key != element.key:
-            revised_index = next(
-                i for i, item in enumerate(revised.rule_elements) if item.key == match.key
-            )
+
+        if element.key not in revised_by_key:
             issues.append(
                 ValidationIssueV1(
-                    code="ELEMENT_KEY_CHANGED",
+                    code="ELEMENT_KEY_DROPPED",
                     severity=ValidationSeverity.warning,
-                    field_path=f"rule_elements[{revised_index}].key",
+                    field_path=f"rule_elements[{index}].key",
                     message=(
-                        f"Element '{element.name}' changed key from '{element.key}' "
-                        f"to '{match.key}' despite preserve_element_keys."
+                        f"Source element key '{element.key}' was not preserved; "
+                        "confirm the conceptual rule was intentionally replaced."
                     ),
                 )
             )
+
+    for index, element in enumerate(source.rule_elements):
+        holder = revised_by_key.get(element.key)
+        if holder is None:
+            continue
+        revised_index, revised_element = holder
+        if _element_identity(
+            revised_element.section.value, revised_element.name
+        ) != _element_identity(element.section.value, element.name):
+            issues.append(
+                ValidationIssueV1(
+                    code="ELEMENT_KEY_REPURPOSED",
+                    severity=ValidationSeverity.warning,
+                    field_path=f"rule_elements[{revised_index}].key",
+                    message=(
+                        f"Key '{element.key}' was reassigned from '{element.name}' "
+                        f"to '{revised_element.name}' despite preserve_element_keys."
+                    ),
+                )
+            )
+
     status = (
         ValidationStatus.invalid
         if any(issue.severity is ValidationSeverity.error for issue in issues)
@@ -328,7 +408,24 @@ def _with_key_preservation_warnings(
         if issues
         else ValidationStatus.valid
     )
-    return receipt.model_copy(update={"issues": issues, "status": status})
+    return receipt.model_copy(
+        update={
+            "issues": issues,
+            "status": status,
+            "validator_version": f"{receipt.validator_version}+{KEY_PRESERVATION_PASS_VERSION}",
+        }
+    )
+
+
+def _group_by_identity(
+    elements: list[RuleElement],
+) -> dict[tuple[str, str], list[tuple[int, RuleElement]]]:
+    groups: dict[tuple[str, str], list[tuple[int, RuleElement]]] = defaultdict(list)
+    for index, element in enumerate(elements):
+        groups[_element_identity(element.section.value, element.name)].append(
+            (index, element)
+        )
+    return groups
 
 
 def _element_identity(section: str, name: str) -> tuple[str, str]:

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -72,6 +72,41 @@ class GenerationFailureV1:
 GenerationResultV1 = GeneratedStatblockCandidateV1 | GenerationFailureV1
 
 
+@dataclass(frozen=True)
+class _PinnedOperationIntent:
+    """Caller-independent operation intent, snapshotted before the provider call.
+
+    Nested models are deep-copied at construction so concurrent mutation of the
+    original command cannot change prompt, digests, ruleset, caller, locator,
+    key-preservation inputs, or asset intent after the operation starts.
+    """
+
+    request_id: str
+    ruleset: RulesetRef
+    caller: CallerProvenanceV1
+    prompt: str
+    source_description_digest: str | None
+    source_definition_digest: str | None
+    source_locator: ExactRevisionLocatorV1 | None
+    source_definition: StatblockDefinitionV1 | None
+    preserve_element_keys: bool
+    asset_prompt: str | None
+    generate_assets: bool
+    include_generation_brief: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "ruleset", self.ruleset.model_copy(deep=True))
+        object.__setattr__(self, "caller", self.caller.model_copy(deep=True))
+        if self.source_locator is not None:
+            object.__setattr__(
+                self, "source_locator", self.source_locator.model_copy(deep=True)
+            )
+        if self.source_definition is not None:
+            object.__setattr__(
+                self, "source_definition", self.source_definition.model_copy(deep=True)
+            )
+
+
 class GenerationServiceV1:
     """Coordinates provider output without letting provider metadata enter the definition."""
 
@@ -95,93 +130,23 @@ class GenerationServiceV1:
         self._asset_generator = asset_generator
 
     def generate(self, command: GenerateStatblockCommandV1) -> GenerationResultV1:
-        digest_error = _verified_source_digest(command.source)
-        if isinstance(digest_error, GenerationFailureV1):
-            return digest_error
-        source_digest = digest_error
-        return self._run(
-            request_id=command.request_id,
-            ruleset=command.ruleset,
-            caller=command.caller,
-            prompt=build_generation_prompt(command),
-            source_digest=source_digest,
-            source_definition_digest=None,
-            source_locator=None,
-            source_definition=None,
-            preserve_element_keys=False,
-            asset_prompt=(
-                command.source.description if command.asset_options.include_generation_brief else None
-            ),
-            generate_assets=command.asset_options.generate_images,
-            include_generation_brief=command.asset_options.include_generation_brief,
-        )
+        pinned = _pin_generate_intent(command)
+        if isinstance(pinned, GenerationFailureV1):
+            return pinned
+        return self._run(pinned)
 
     def revise(self, command: ReviseStatblockCommandV1) -> GenerationResultV1:
-        source = command.source_definition
-        source_locator = command.source_locator
-        if source is None:
-            if source_locator is None:
-                return GenerationFailureV1("invalid_request", "Revision source is missing")
-            if self._definition_resolver is None:
-                return GenerationFailureV1(
-                    "source_unavailable", "No definition resolver is configured"
-                )
-            try:
-                source = self._definition_resolver.resolve(source_locator)
-            except StatblockV1Error as error:
-                return GenerationFailureV1(error.code, error.message)
-            except Exception:
-                return GenerationFailureV1(
-                    "source_unavailable", "Failed to resolve source revision"
-                )
+        pinned = _pin_revise_intent(command, self._definition_resolver)
+        if isinstance(pinned, GenerationFailureV1):
+            return pinned
+        return self._run(pinned)
 
-        source_digest: str | None = None
-        if command.source is not None:
-            digest_error = _verified_source_digest(command.source)
-            if isinstance(digest_error, GenerationFailureV1):
-                return digest_error
-            source_digest = digest_error
-
-        return self._run(
-            request_id=command.request_id,
-            ruleset=command.ruleset,
-            caller=command.caller,
-            prompt=build_revision_prompt(command, source),
-            source_digest=source_digest,
-            source_definition_digest=compute_definition_digest(source),
-            source_locator=source_locator,
-            source_definition=source,
-            preserve_element_keys=command.preserve_element_keys,
-            asset_prompt=(
-                command.source.description
-                if command.source and command.asset_options.include_generation_brief
-                else None
-            ),
-            generate_assets=command.asset_options.generate_images,
-            include_generation_brief=command.asset_options.include_generation_brief,
-        )
-
-    def _run(
-        self,
-        *,
-        request_id: str,
-        ruleset: RulesetRef,
-        caller: CallerProvenanceV1,
-        prompt: str,
-        source_digest: str | None,
-        source_definition_digest: str | None,
-        source_locator: ExactRevisionLocatorV1 | None,
-        source_definition: StatblockDefinitionV1 | None,
-        preserve_element_keys: bool,
-        asset_prompt: str | None,
-        generate_assets: bool,
-        include_generation_brief: bool,
-    ) -> GenerationResultV1:
+    def _run(self, intent: _PinnedOperationIntent) -> GenerationResultV1:
         compiled = compile_openai_definition_schema()
         started = time.monotonic()
         try:
             outcome = self._provider.generate_definition(
-                prompt=prompt,
+                prompt=intent.prompt,
                 schema=compiled,
                 options=ProviderOptionsV1(
                     model=self._settings.model,
@@ -208,7 +173,7 @@ class GenerationServiceV1:
             return GenerationFailureV1(
                 "definition_invalid", "Provider output does not match StatblockDefinitionV1"
             )
-        if not _ruleset_matches(definition.ruleset, ruleset):
+        if not _ruleset_matches(definition.ruleset, intent.ruleset):
             return GenerationFailureV1(
                 "ruleset_mismatch",
                 "Generated definition ruleset does not match the requested ruleset",
@@ -222,16 +187,18 @@ class GenerationServiceV1:
             return GenerationFailureV1(
                 "definition_invalid", "Provider output has structural or reference errors"
             )
-        if source_definition is not None and preserve_element_keys:
-            receipt = _with_key_preservation_warnings(receipt, source_definition, definition)
+        if intent.source_definition is not None and intent.preserve_element_keys:
+            receipt = _with_key_preservation_warnings(
+                receipt, intent.source_definition, definition
+            )
 
         asset_warnings: list[AssetWarningV1] = []
         assets: list[dict[str, object]] = []
         asset_brief_model: AssetBriefV1 | None = None
-        if generate_assets:
+        if intent.generate_assets:
             # When images are requested, always persist the exact brief used.
             # Without an authored description brief, fall back to the creature name.
-            effective_prompt = asset_prompt or definition.identity.name
+            effective_prompt = intent.asset_prompt or definition.identity.name
             asset_brief_model = AssetBriefV1(prompt=effective_prompt)
             if self._asset_generator is None:
                 asset_warnings.append(
@@ -252,8 +219,8 @@ class GenerationServiceV1:
                             message="Asset generation failed; review the candidate without assets.",
                         )
                     )
-        elif include_generation_brief and asset_prompt is not None:
-            asset_brief_model = AssetBriefV1(prompt=asset_prompt)
+        elif intent.include_generation_brief and intent.asset_prompt is not None:
+            asset_brief_model = AssetBriefV1(prompt=intent.asset_prompt)
 
         measured_latency_ms = int((time.monotonic() - started) * 1000)
         latency_ms = (
@@ -265,18 +232,18 @@ class GenerationServiceV1:
             definition=definition,
             validation_receipt=receipt,
             generation_receipt=GenerationReceiptV1(
-                request_id=request_id,
+                request_id=intent.request_id,
                 provider=self._provider.provider_name,
                 model=self._settings.model,
                 prompt_version=PROMPT_VERSION,
                 schema_version=compiled.compiler_version,
                 schema_fingerprint=compiled.fingerprint,
                 generated_at=now,
-                caller_scope=caller.caller_scope,
-                actor=caller.actor,
-                source_description_digest=source_digest,
-                source_definition_digest=source_definition_digest,
-                source_locator=source_locator,
+                caller_scope=intent.caller.caller_scope,
+                actor=intent.caller.actor,
+                source_description_digest=intent.source_description_digest,
+                source_definition_digest=intent.source_definition_digest,
+                source_locator=intent.source_locator,
                 provider_request_id=outcome.request_id,
                 provider_response_id=outcome.response_id,
                 latency_ms=latency_ms,
@@ -290,9 +257,90 @@ class GenerationServiceV1:
             asset_warnings=asset_warnings,
             created_at=now,
             expires_at=now + timedelta(seconds=self._settings.candidate_ttl_seconds),
-            source_locator=source_locator,
+            source_locator=intent.source_locator,
         )
         return self._candidates.create(candidate)
+
+
+def _pin_generate_intent(
+    command: GenerateStatblockCommandV1,
+) -> _PinnedOperationIntent | GenerationFailureV1:
+    """Deep-copy and derive all generate inputs before any provider call."""
+
+    snapshot = command.model_copy(deep=True)
+    digest_error = _verified_source_digest(snapshot.source)
+    if isinstance(digest_error, GenerationFailureV1):
+        return digest_error
+    return _PinnedOperationIntent(
+        request_id=snapshot.request_id,
+        ruleset=snapshot.ruleset,
+        caller=snapshot.caller,
+        prompt=build_generation_prompt(snapshot),
+        source_description_digest=digest_error,
+        source_definition_digest=None,
+        source_locator=None,
+        source_definition=None,
+        preserve_element_keys=False,
+        asset_prompt=(
+            snapshot.source.description if snapshot.asset_options.include_generation_brief else None
+        ),
+        generate_assets=snapshot.asset_options.generate_images,
+        include_generation_brief=snapshot.asset_options.include_generation_brief,
+    )
+
+
+def _pin_revise_intent(
+    command: ReviseStatblockCommandV1,
+    definition_resolver: DefinitionResolver | None,
+) -> _PinnedOperationIntent | GenerationFailureV1:
+    """Deep-copy and derive all revise inputs before any provider call."""
+
+    snapshot = command.model_copy(deep=True)
+    source = snapshot.source_definition
+    source_locator = snapshot.source_locator
+    if source is None:
+        if source_locator is None:
+            return GenerationFailureV1("invalid_request", "Revision source is missing")
+        if definition_resolver is None:
+            return GenerationFailureV1(
+                "source_unavailable", "No definition resolver is configured"
+            )
+        try:
+            source = definition_resolver.resolve(source_locator).model_copy(deep=True)
+        except StatblockV1Error as error:
+            return GenerationFailureV1(error.code, error.message)
+        except Exception:
+            return GenerationFailureV1(
+                "source_unavailable", "Failed to resolve source revision"
+            )
+    else:
+        source = source.model_copy(deep=True)
+
+    source_digest: str | None = None
+    if snapshot.source is not None:
+        digest_error = _verified_source_digest(snapshot.source)
+        if isinstance(digest_error, GenerationFailureV1):
+            return digest_error
+        source_digest = digest_error
+
+    return _PinnedOperationIntent(
+        request_id=snapshot.request_id,
+        ruleset=snapshot.ruleset,
+        caller=snapshot.caller,
+        prompt=build_revision_prompt(snapshot, source),
+        source_description_digest=source_digest,
+        source_definition_digest=compute_definition_digest(source),
+        source_locator=source_locator,
+        source_definition=source,
+        preserve_element_keys=snapshot.preserve_element_keys,
+        asset_prompt=(
+            snapshot.source.description
+            if snapshot.source and snapshot.asset_options.include_generation_brief
+            else None
+        ),
+        generate_assets=snapshot.asset_options.generate_images,
+        include_generation_brief=snapshot.asset_options.include_generation_brief,
+    )
 
 
 def _verified_source_digest(source: SourceSnapshotV1) -> str | GenerationFailureV1:

--- a/statblocks_v1/application/prompts.py
+++ b/statblocks_v1/application/prompts.py
@@ -13,11 +13,8 @@ Create one creature named {command.source.name_hint!r}.
 Source description:
 {command.source.description}
 
-Intent: target CR={command.intent.target_cr or "use the description"}, roles={_items(command.intent.roles)},
-complexity={command.intent.complexity or "appropriate"}, must include={_items(command.intent.must_include)},
-must avoid={_items(command.intent.must_avoid)}.
-Encounter context: party level={command.context.party_level or "unspecified"}, party size={command.context.party_size or "unspecified"},
-terrain={_items(command.context.terrain_notes)}.
+{_intent_block(command.intent)}
+{_context_block(command.context)}
 """
 
 
@@ -29,21 +26,49 @@ def build_revision_prompt(
         if command.preserve_element_keys
         else "You may replace local keys when replacing the corresponding conceptual rule."
     )
+    source_description = ""
+    if command.source is not None:
+        source_description = f"""
+Updated authored description ({command.source.name_hint!r}):
+{command.source.description}
+"""
     return _base_prompt(command.ruleset.edition.value) + f"""
 Revise this exact source definition according to: {_items(command.revision_instructions)}.
 {preservation}
+{_intent_block(command.intent)}
+{_context_block(command.context)}
+{source_description}
 Return a complete replacement definition, with no wrapper or commentary.
 Source definition JSON:
 {source.model_dump_json(exclude_none=False)}
 """
 
 
+def _intent_block(intent) -> str:
+    return (
+        f"Intent: target CR={intent.target_cr or 'use the description'}, "
+        f"roles={_items(intent.roles)}, complexity={intent.complexity or 'appropriate'}, "
+        f"must include={_items(intent.must_include)}, must avoid={_items(intent.must_avoid)}."
+    )
+
+
+def _context_block(context) -> str:
+    return (
+        f"Encounter context: party level={context.party_level or 'unspecified'}, "
+        f"party size={context.party_size or 'unspecified'}, "
+        f"terrain={_items(context.terrain_notes)}."
+    )
+
+
 def _base_prompt(edition: str) -> str:
-    edition_guidance = "Use 2014 D&D 5e terminology and conventions." if edition == "2014" else (
-        "Use 2024 D&D 5e terminology and conventions; do not mix 2014-only wording unless necessary."
+    edition_guidance = (
+        "Use 2014 D&D 5e terminology and conventions."
+        if edition == "2014"
+        else "Use 2024 D&D 5e terminology and conventions; do not mix 2014-only wording unless necessary."
     )
     return f"""You produce only a StatblockDefinitionV1 JSON object for D&D 5e {edition}.
 {edition_guidance}
+The definition.ruleset.system and definition.ruleset.edition fields must exactly match the requested ruleset.
 Do not generate candidate IDs, timestamps, digests, provenance, assets, Markdown, or any outer envelope.
 Every definition-local key is a stable lowercase identifier used by internal references. Keep them unique.
 A section is where a rule appears (trait/action/reaction/etc.); activation is how it is used; mechanic.kind is its typed behavior.

--- a/statblocks_v1/application/prompts.py
+++ b/statblocks_v1/application/prompts.py
@@ -1,0 +1,56 @@
+"""Versioned, definition-only prompts for structured statblock generation."""
+from __future__ import annotations
+
+from statblocks_v1.application.commands import GenerateStatblockCommandV1, ReviseStatblockCommandV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+PROMPT_VERSION = "statblock-generation-prompt-v1"
+
+
+def build_generation_prompt(command: GenerateStatblockCommandV1) -> str:
+    return _base_prompt(command.ruleset.edition.value) + f"""
+Create one creature named {command.source.name_hint!r}.
+Source description:
+{command.source.description}
+
+Intent: target CR={command.intent.target_cr or "use the description"}, roles={_items(command.intent.roles)},
+complexity={command.intent.complexity or "appropriate"}, must include={_items(command.intent.must_include)},
+must avoid={_items(command.intent.must_avoid)}.
+Encounter context: party level={command.context.party_level or "unspecified"}, party size={command.context.party_size or "unspecified"},
+terrain={_items(command.context.terrain_notes)}.
+"""
+
+
+def build_revision_prompt(
+    command: ReviseStatblockCommandV1, source: StatblockDefinitionV1
+) -> str:
+    preservation = (
+        "Preserve existing rule-element local keys whenever their conceptual rule remains."
+        if command.preserve_element_keys
+        else "You may replace local keys when replacing the corresponding conceptual rule."
+    )
+    return _base_prompt(command.ruleset.edition.value) + f"""
+Revise this exact source definition according to: {_items(command.revision_instructions)}.
+{preservation}
+Return a complete replacement definition, with no wrapper or commentary.
+Source definition JSON:
+{source.model_dump_json(exclude_none=False)}
+"""
+
+
+def _base_prompt(edition: str) -> str:
+    edition_guidance = "Use 2014 D&D 5e terminology and conventions." if edition == "2014" else (
+        "Use 2024 D&D 5e terminology and conventions; do not mix 2014-only wording unless necessary."
+    )
+    return f"""You produce only a StatblockDefinitionV1 JSON object for D&D 5e {edition}.
+{edition_guidance}
+Do not generate candidate IDs, timestamps, digests, provenance, assets, Markdown, or any outer envelope.
+Every definition-local key is a stable lowercase identifier used by internal references. Keep them unique.
+A section is where a rule appears (trait/action/reaction/etc.); activation is how it is used; mechanic.kind is its typed behavior.
+Provide complete table-facing rules_text for every rule element even when typed mechanics are present.
+When a mechanic cannot be represented safely by the typed contract, use mechanic.kind "human_adjudicated" and manual automation support; never invent fields.
+"""
+
+
+def _items(values: list[str]) -> str:
+    return ", ".join(values) if values else "none"

--- a/statblocks_v1/application/provider.py
+++ b/statblocks_v1/application/provider.py
@@ -1,0 +1,48 @@
+"""Provider seam and stable outcomes for definition-only generation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+from statblocks_v1.application.schema_compiler import CompiledSchemaV1
+
+
+class ProviderOutcomeKind(str, Enum):
+    success = "success"
+    refusal = "refusal"
+    incomplete = "incomplete"
+    timeout = "timeout"
+    rate_limit = "rate_limit"
+    failure = "failure"
+
+
+@dataclass(frozen=True)
+class ProviderOutcomeV1:
+    kind: ProviderOutcomeKind
+    payload: dict[str, Any] | None = None
+    message: str | None = None
+    request_id: str | None = None
+    response_id: str | None = None
+    latency_ms: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+    @classmethod
+    def succeeded(cls, payload: dict[str, Any], **metadata: Any) -> "ProviderOutcomeV1":
+        return cls(kind=ProviderOutcomeKind.success, payload=payload, **metadata)
+
+
+@dataclass(frozen=True)
+class ProviderOptionsV1:
+    model: str
+    timeout_seconds: float
+    max_retries: int
+
+
+class DefinitionProvider(Protocol):
+    provider_name: str
+
+    def generate_definition(
+        self, *, prompt: str, schema: CompiledSchemaV1, options: ProviderOptionsV1
+    ) -> ProviderOutcomeV1: ...

--- a/statblocks_v1/application/resolvers.py
+++ b/statblocks_v1/application/resolvers.py
@@ -1,0 +1,18 @@
+"""Definition resolvers that speak PR15 persistence read contracts."""
+from __future__ import annotations
+
+from statblocks_v1.application.repositories import StatblockPersistenceRepository
+from statblocks_v1.domain.resources import ExactRevisionLocatorV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+
+class PersistenceDefinitionResolver:
+    """Resolve an exact revision through ``get_revision(statblock_id, revision_id)``."""
+
+    def __init__(self, repository: StatblockPersistenceRepository) -> None:
+        self._repository = repository
+
+    def resolve(self, locator: ExactRevisionLocatorV1) -> StatblockDefinitionV1:
+        return self._repository.get_revision(
+            locator.statblock_id, locator.revision_id
+        ).definition

--- a/statblocks_v1/application/schema_compiler.py
+++ b/statblocks_v1/application/schema_compiler.py
@@ -1,0 +1,52 @@
+"""Provider-schema compilation over the published OpenAI strict artifact."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from statblocks_v1.domain.schema import SCHEMA_ARTIFACT_DIRECTORY, openai_strict_json_schema
+
+SCHEMA_COMPILER_VERSION = "statblock-openai-strict-compiler-v1"
+
+
+@dataclass(frozen=True)
+class CompiledSchemaV1:
+    name: str
+    schema: dict[str, Any]
+    compiler_version: str
+    fingerprint: str
+
+
+def compile_openai_definition_schema() -> CompiledSchemaV1:
+    """Load the reviewed strict artifact and reject a stale contract publication."""
+    artifact = SCHEMA_ARTIFACT_DIRECTORY / "statblock_definition_v1.openai-strict.schema.json"
+    schema = json.loads(artifact.read_text(encoding="utf-8"))
+    if schema != openai_strict_json_schema():
+        raise ValueError(
+            "OpenAI strict schema artifact is stale; regenerate schema artifacts before deployment"
+        )
+    _assert_closed_objects(schema)
+    encoded = json.dumps(schema, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    return CompiledSchemaV1(
+        name="statblock_definition_v1",
+        schema=schema,
+        compiler_version=SCHEMA_COMPILER_VERSION,
+        fingerprint=f"sha256:{hashlib.sha256(encoded).hexdigest()}",
+    )
+
+
+def _assert_closed_objects(node: Any) -> None:
+    if isinstance(node, list):
+        for item in node:
+            _assert_closed_objects(item)
+    elif isinstance(node, dict):
+        if node.get("type") == "object" or "properties" in node:
+            if node.get("additionalProperties") is not False:
+                raise ValueError("OpenAI strict compilation left an object open")
+            if set(node.get("required", ())) != set(node.get("properties", ())):
+                raise ValueError("OpenAI strict compilation omitted required properties")
+        for value in node.values():
+            _assert_closed_objects(value)

--- a/statblocks_v1/application/settings.py
+++ b/statblocks_v1/application/settings.py
@@ -1,0 +1,31 @@
+"""Environment settings for the structured-generation provider."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _policy_model() -> str:
+    policy_path = Path(__file__).resolve().parents[3] / "MODEL_POLICY.json"
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    role = policy["actions"]["structured_generation"]
+    return policy["models"][role]
+
+
+@dataclass(frozen=True)
+class GenerationSettingsV1:
+    model: str
+    timeout_seconds: float
+    max_retries: int
+    candidate_ttl_seconds: int
+
+    @classmethod
+    def from_environment(cls) -> "GenerationSettingsV1":
+        return cls(
+            model=os.getenv("STATBLOCKS_V1_OPENAI_MODEL", _policy_model()),
+            timeout_seconds=float(os.getenv("STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS", "45")),
+            max_retries=int(os.getenv("STATBLOCKS_V1_OPENAI_MAX_RETRIES", "1")),
+            candidate_ttl_seconds=int(os.getenv("STATBLOCKS_V1_CANDIDATE_TTL_SECONDS", "86400")),
+        )

--- a/statblocks_v1/application/settings.py
+++ b/statblocks_v1/application/settings.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -35,12 +36,57 @@ class GenerationSettingsV1:
     max_retries: int
     candidate_ttl_seconds: int
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.model, str) or not self.model.strip():
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_OPENAI_MODEL must be a non-empty string"
+            )
+        if isinstance(self.timeout_seconds, bool) or not isinstance(
+            self.timeout_seconds, (int, float)
+        ):
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS must be a finite positive number"
+            )
+        if not math.isfinite(float(self.timeout_seconds)) or float(self.timeout_seconds) <= 0:
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS must be a finite positive number"
+            )
+        if isinstance(self.max_retries, bool) or not isinstance(self.max_retries, int):
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_OPENAI_MAX_RETRIES must be an integer >= 0"
+            )
+        if self.max_retries < 0:
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_OPENAI_MAX_RETRIES must be an integer >= 0"
+            )
+        if isinstance(self.candidate_ttl_seconds, bool) or not isinstance(
+            self.candidate_ttl_seconds, int
+        ):
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_CANDIDATE_TTL_SECONDS must be an integer > 0"
+            )
+        if self.candidate_ttl_seconds <= 0:
+            raise InternalServiceMisconfiguredError(
+                "STATBLOCKS_V1_CANDIDATE_TTL_SECONDS must be an integer > 0"
+            )
+
     @classmethod
     def from_environment(cls) -> "GenerationSettingsV1":
-        configured = os.getenv("STATBLOCKS_V1_OPENAI_MODEL")
-        return cls(
-            model=configured if configured else _policy_model(),
-            timeout_seconds=float(os.getenv("STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS", "45")),
-            max_retries=int(os.getenv("STATBLOCKS_V1_OPENAI_MAX_RETRIES", "1")),
-            candidate_ttl_seconds=int(os.getenv("STATBLOCKS_V1_CANDIDATE_TTL_SECONDS", "86400")),
-        )
+        try:
+            configured = os.getenv("STATBLOCKS_V1_OPENAI_MODEL")
+            return cls(
+                model=configured if configured else _policy_model(),
+                timeout_seconds=float(
+                    os.getenv("STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS", "45")
+                ),
+                max_retries=int(os.getenv("STATBLOCKS_V1_OPENAI_MAX_RETRIES", "1")),
+                candidate_ttl_seconds=int(
+                    os.getenv("STATBLOCKS_V1_CANDIDATE_TTL_SECONDS", "86400")
+                ),
+            )
+        except InternalServiceMisconfiguredError:
+            raise
+        except (TypeError, ValueError) as error:
+            raise InternalServiceMisconfiguredError(
+                "Generation settings environment values are malformed"
+            ) from error

--- a/statblocks_v1/application/settings.py
+++ b/statblocks_v1/application/settings.py
@@ -6,12 +6,26 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from statblocks_v1.domain.errors import InternalServiceMisconfiguredError
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 def _policy_model() -> str:
-    policy_path = Path(__file__).resolve().parents[3] / "MODEL_POLICY.json"
-    policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    role = policy["actions"]["structured_generation"]
-    return policy["models"][role]
+    """Resolve structured_generation from the in-repo MODEL_POLICY.json only."""
+    policy_path = _REPO_ROOT / "MODEL_POLICY.json"
+    if not policy_path.is_file():
+        raise InternalServiceMisconfiguredError(
+            "MODEL_POLICY.json is missing from the DungeonMindServer repository root"
+        )
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        role = policy["actions"]["structured_generation"]
+        return policy["models"][role]
+    except (KeyError, TypeError, json.JSONDecodeError) as error:
+        raise InternalServiceMisconfiguredError(
+            "MODEL_POLICY.json does not define actions.structured_generation"
+        ) from error
 
 
 @dataclass(frozen=True)
@@ -23,8 +37,9 @@ class GenerationSettingsV1:
 
     @classmethod
     def from_environment(cls) -> "GenerationSettingsV1":
+        configured = os.getenv("STATBLOCKS_V1_OPENAI_MODEL")
         return cls(
-            model=os.getenv("STATBLOCKS_V1_OPENAI_MODEL", _policy_model()),
+            model=configured if configured else _policy_model(),
             timeout_seconds=float(os.getenv("STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS", "45")),
             max_retries=int(os.getenv("STATBLOCKS_V1_OPENAI_MAX_RETRIES", "1")),
             candidate_ttl_seconds=int(os.getenv("STATBLOCKS_V1_CANDIDATE_TTL_SECONDS", "86400")),

--- a/statblocks_v1/domain/resources.py
+++ b/statblocks_v1/domain/resources.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from typing import Any
 
 from pydantic import Field
@@ -33,6 +34,20 @@ class IdempotencyOutcomeV1(StrictModel):
     revision_id: str = Field(pattern=r"^rev_[a-z0-9]+$")
 
 
+class AssetWarningCode(str, Enum):
+    """Stable machine-readable codes for candidate asset partial outcomes."""
+
+    asset_generator_unconfigured = "asset_generator_unconfigured"
+    asset_generation_failed = "asset_generation_failed"
+
+
+class AssetWarningV1(StrictModel):
+    """Typed partial-outcome warning for optional asset generation."""
+
+    code: AssetWarningCode
+    message: str = Field(min_length=1)
+
+
 class GenerationReceiptV1(StrictModel):
     """Extensible, server-owned audit data populated by the generation service."""
 
@@ -46,6 +61,9 @@ class GenerationReceiptV1(StrictModel):
     caller_scope: str = Field(min_length=1)
     actor: str | None = None
     source_description_digest: str | None = None
+    source_definition_digest: str | None = Field(
+        default=None, pattern=r"^sha256:[0-9a-f]{64}$"
+    )
     source_locator: ExactRevisionLocatorV1 | None = None
     provider_request_id: str | None = None
     provider_response_id: str | None = None
@@ -63,7 +81,7 @@ class GeneratedStatblockCandidateV1(StrictModel):
     generation_receipt: GenerationReceiptV1 | None = None
     asset_brief: dict[str, Any] | None = None
     assets: list[dict[str, Any]] = Field(default_factory=list)
-    asset_warnings: list[str] = Field(default_factory=list)
+    asset_warnings: list[AssetWarningV1] = Field(default_factory=list)
     created_at: datetime
     expires_at: datetime
     source_locator: ExactRevisionLocatorV1 | None = None

--- a/statblocks_v1/domain/resources.py
+++ b/statblocks_v1/domain/resources.py
@@ -54,6 +54,7 @@ class GeneratedStatblockCandidateV1(StrictModel):
     generation_receipt: GenerationReceiptV1 | None = None
     asset_brief: dict[str, Any] | None = None
     assets: list[dict[str, Any]] = Field(default_factory=list)
+    asset_warnings: list[str] = Field(default_factory=list)
     created_at: datetime
     expires_at: datetime
     source_locator: ResourceLocatorV1 | None = None

--- a/statblocks_v1/domain/resources.py
+++ b/statblocks_v1/domain/resources.py
@@ -19,6 +19,13 @@ class ResourceLocatorV1(StrictModel):
     resource_id: str = Field(min_length=1)
 
 
+class ExactRevisionLocatorV1(StrictModel):
+    """Exact persisted revision coordinates for PR15 ``get_revision`` reads."""
+
+    statblock_id: str = Field(pattern=r"^sb_[a-z0-9]+$")
+    revision_id: str = Field(pattern=r"^rev_[a-z0-9]+$")
+
+
 class IdempotencyOutcomeV1(StrictModel):
     """Exact create/append result pinned for durable replay."""
 
@@ -36,8 +43,10 @@ class GenerationReceiptV1(StrictModel):
     schema_version: str = Field(min_length=1)
     schema_fingerprint: str = Field(min_length=1)
     generated_at: datetime
+    caller_scope: str = Field(min_length=1)
+    actor: str | None = None
     source_description_digest: str | None = None
-    source_locator: ResourceLocatorV1 | None = None
+    source_locator: ExactRevisionLocatorV1 | None = None
     provider_request_id: str | None = None
     provider_response_id: str | None = None
     latency_ms: int | None = Field(default=None, ge=0)
@@ -57,7 +66,7 @@ class GeneratedStatblockCandidateV1(StrictModel):
     asset_warnings: list[str] = Field(default_factory=list)
     created_at: datetime
     expires_at: datetime
-    source_locator: ResourceLocatorV1 | None = None
+    source_locator: ExactRevisionLocatorV1 | None = None
 
 
 class StatblockResourceV1(StrictModel):

--- a/statblocks_v1/infrastructure/fake_provider.py
+++ b/statblocks_v1/infrastructure/fake_provider.py
@@ -1,0 +1,32 @@
+"""Deterministic definition provider used by offline tests and DI overrides."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from statblocks_v1.application.provider import ProviderOptionsV1, ProviderOutcomeV1
+from statblocks_v1.application.schema_compiler import CompiledSchemaV1
+
+
+class FakeDefinitionProvider:
+    provider_name = "fake"
+
+    def __init__(
+        self,
+        outcome: ProviderOutcomeV1 | dict[str, Any],
+        *,
+        callback: Callable[[str, CompiledSchemaV1, ProviderOptionsV1], ProviderOutcomeV1] | None = None,
+    ) -> None:
+        self._outcome = outcome
+        self._callback = callback
+        self.calls: list[tuple[str, CompiledSchemaV1, ProviderOptionsV1]] = []
+
+    def generate_definition(
+        self, *, prompt: str, schema: CompiledSchemaV1, options: ProviderOptionsV1
+    ) -> ProviderOutcomeV1:
+        self.calls.append((prompt, schema, options))
+        if self._callback:
+            return self._callback(prompt, schema, options)
+        if isinstance(self._outcome, dict):
+            return ProviderOutcomeV1.succeeded(self._outcome)
+        return self._outcome

--- a/statblocks_v1/infrastructure/openai_provider.py
+++ b/statblocks_v1/infrastructure/openai_provider.py
@@ -1,0 +1,76 @@
+"""OpenAI Structured Outputs adapter; the domain never imports this module."""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from statblocks_v1.application.provider import (
+    ProviderOptionsV1,
+    ProviderOutcomeKind,
+    ProviderOutcomeV1,
+)
+from statblocks_v1.application.schema_compiler import CompiledSchemaV1
+
+
+class OpenAIDefinitionProvider:
+    provider_name = "openai"
+
+    def __init__(self, client: Any | None = None) -> None:
+        if client is None:
+            from openai import OpenAI
+
+            client = OpenAI()
+        self._client = client
+
+    def generate_definition(
+        self, *, prompt: str, schema: CompiledSchemaV1, options: ProviderOptionsV1
+    ) -> ProviderOutcomeV1:
+        started = time.monotonic()
+        try:
+            client = (
+                self._client.with_options(timeout=options.timeout_seconds, max_retries=options.max_retries)
+                if hasattr(self._client, "with_options")
+                else self._client
+            )
+            response = client.chat.completions.create(
+                model=options.model,
+                messages=[
+                    {"role": "system", "content": "Return only the requested JSON schema instance."},
+                    {"role": "user", "content": prompt},
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"name": schema.name, "strict": True, "schema": schema.schema},
+                },
+            )
+            message = response.choices[0].message
+            metadata = _metadata(response, started)
+            if getattr(message, "refusal", None):
+                return ProviderOutcomeV1(ProviderOutcomeKind.refusal, message="Provider refused request", **metadata)
+            content = getattr(message, "content", None)
+            if not content:
+                return ProviderOutcomeV1(ProviderOutcomeKind.incomplete, message="Provider returned no JSON", **metadata)
+            try:
+                return ProviderOutcomeV1.succeeded(json.loads(content), **metadata)
+            except json.JSONDecodeError:
+                return ProviderOutcomeV1(ProviderOutcomeKind.incomplete, message="Provider returned malformed JSON", **metadata)
+        except Exception as exc:
+            name = type(exc).__name__.lower()
+            kind = (
+                ProviderOutcomeKind.rate_limit if "ratelimit" in name else
+                ProviderOutcomeKind.timeout if "timeout" in name else
+                ProviderOutcomeKind.failure
+            )
+            return ProviderOutcomeV1(kind, message="OpenAI request failed", latency_ms=int((time.monotonic() - started) * 1000))
+
+
+def _metadata(response: Any, started: float) -> dict[str, Any]:
+    usage = getattr(response, "usage", None)
+    return {
+        "request_id": getattr(response, "_request_id", None),
+        "response_id": getattr(response, "id", None),
+        "latency_ms": int((time.monotonic() - started) * 1000),
+        "input_tokens": getattr(usage, "prompt_tokens", None),
+        "output_tokens": getattr(usage, "completion_tokens", None),
+    }

--- a/tests/statblocks_v1/integration/test_firestore_repositories.py
+++ b/tests/statblocks_v1/integration/test_firestore_repositories.py
@@ -2,15 +2,23 @@
 from __future__ import annotations
 
 import os
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from statblocks_v1.application.repositories import AppendRevisionCommand, CreateStatblockCommand
+from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import StaleParentRevisionError, StatblockNotFoundError
 from statblocks_v1.domain.receipts import ValidationMode
-from statblocks_v1.domain.resources import GeneratedStatblockCandidateV1
+from statblocks_v1.domain.resources import (
+    AssetWarningCode,
+    AssetWarningV1,
+    ExactRevisionLocatorV1,
+    GeneratedStatblockCandidateV1,
+    GenerationReceiptV1,
+)
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
 from statblocks_v1.infrastructure.firestore_repositories import (
@@ -97,7 +105,7 @@ def test_firestore_candidate_ttl_timestamp_round_trip(firestore_client, bruiser)
     created = datetime(2026, 1, 1, tzinfo=timezone.utc)
     expires = created + timedelta(hours=2)
     candidate = GeneratedStatblockCandidateV1(
-        candidate_id="cand_fs0001",
+        candidate_id=f"cand_fs{uuid.uuid4().hex[:10]}",
         definition=bruiser,
         validation_receipt=validate_definition(bruiser, ValidationMode.generation_candidate),
         created_at=created,
@@ -113,6 +121,94 @@ def test_firestore_candidate_ttl_timestamp_round_trip(firestore_client, bruiser)
     assert isinstance(raw["expires_at"], datetime)
     loaded = repository.get(candidate.candidate_id, now=created)
     assert loaded.expires_at == expires
+
+
+def test_firestore_candidate_typed_contract_round_trip(firestore_client, bruiser):
+    repository = FirestoreCandidateRepository(firestore_client)
+    created = datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc)
+    expires = created + timedelta(hours=6)
+    locator = ExactRevisionLocatorV1(statblock_id="sb_fsource01", revision_id="rev_fsource01")
+    source_definition_digest = compute_definition_digest(bruiser)
+    candidate_id = f"cand_fs{uuid.uuid4().hex[:10]}"
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id=candidate_id,
+        definition=bruiser,
+        validation_receipt=validate_definition(
+            bruiser, ValidationMode.generation_candidate, validated_at=created
+        ),
+        generation_receipt=GenerationReceiptV1(
+            request_id="req_fs_typed",
+            provider="fake",
+            model="test-model",
+            prompt_version="statblock-generation-prompt-v1",
+            schema_version="statblock-openai-schema-v1",
+            schema_fingerprint="fp_test",
+            generated_at=created,
+            caller_scope="dungeonbuddy",
+            actor="emulator",
+            source_description_digest="sha256:" + ("a" * 64),
+            source_definition_digest=source_definition_digest,
+            source_locator=locator,
+            latency_ms=0,
+        ),
+        asset_brief={
+            "prompt": "Emulator round-trip creature",
+            "recommended_roles": ["portrait", "token"],
+        },
+        assets=[{"role": "portrait", "url": "https://example.test/portrait.png"}],
+        asset_warnings=[
+            AssetWarningV1(
+                code=AssetWarningCode.asset_generator_unconfigured,
+                message="Asset generation was requested but no asset generator is configured.",
+            ),
+            AssetWarningV1(
+                code=AssetWarningCode.asset_generation_failed,
+                message="Asset generation failed; review the candidate without assets.",
+            ),
+        ],
+        created_at=created,
+        expires_at=expires,
+        source_locator=locator,
+    )
+
+    repository.create(candidate)
+    raw = (
+        firestore_client.collection(CANDIDATES_COLLECTION)
+        .document(candidate_id)
+        .get()
+        .to_dict()
+    )
+    assert isinstance(raw["expires_at"], datetime)
+    assert isinstance(raw["created_at"], datetime)
+    assert isinstance(raw["generation_receipt"]["generated_at"], datetime)
+    assert raw["generation_receipt"]["source_definition_digest"] == source_definition_digest
+    assert raw["generation_receipt"]["source_locator"] == {
+        "statblock_id": "sb_fsource01",
+        "revision_id": "rev_fsource01",
+    }
+    assert raw["asset_warnings"] == [
+        {
+            "code": "asset_generator_unconfigured",
+            "message": "Asset generation was requested but no asset generator is configured.",
+        },
+        {
+            "code": "asset_generation_failed",
+            "message": "Asset generation failed; review the candidate without assets.",
+        },
+    ]
+    assert raw["asset_brief"]["prompt"] == "Emulator round-trip creature"
+
+    loaded = repository.get(candidate_id, now=created)
+    assert loaded.model_dump(mode="json") == candidate.model_dump(mode="json")
+    assert loaded.generation_receipt is not None
+    assert loaded.generation_receipt.source_definition_digest == source_definition_digest
+    assert loaded.generation_receipt.source_locator == locator
+    assert loaded.source_locator == locator
+    assert [warning.code for warning in loaded.asset_warnings] == [
+        AssetWarningCode.asset_generator_unconfigured,
+        AssetWarningCode.asset_generation_failed,
+    ]
+    assert loaded.asset_brief == candidate.asset_brief
 
 
 def test_firestore_concurrent_append_only_one_succeeds(firestore_client, bruiser):

--- a/tests/statblocks_v1/integration/test_openai_generation.py
+++ b/tests/statblocks_v1/integration/test_openai_generation.py
@@ -1,0 +1,22 @@
+"""Opt-in smoke coverage for the real Structured Outputs adapter."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.infrastructure.openai_provider import OpenAIDefinitionProvider
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("RUN_OPENAI_GENERATION_TESTS") or not os.getenv("OPENAI_API_KEY"),
+    reason="requires RUN_OPENAI_GENERATION_TESTS=1 and OPENAI_API_KEY",
+)
+
+
+def test_openai_provider_is_constructible_with_opt_in_credentials() -> None:
+    """Network calls belong in a separately enabled smoke suite."""
+    provider = OpenAIDefinitionProvider()
+
+    assert provider.provider_name == "openai"
+    assert GenerationSettingsV1.from_environment().model

--- a/tests/statblocks_v1/integration/test_openai_generation.py
+++ b/tests/statblocks_v1/integration/test_openai_generation.py
@@ -5,7 +5,10 @@ import os
 
 import pytest
 
+from statblocks_v1.application.provider import ProviderOptionsV1, ProviderOutcomeKind
+from statblocks_v1.application.schema_compiler import compile_openai_definition_schema
 from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.infrastructure.openai_provider import OpenAIDefinitionProvider
 
 pytestmark = pytest.mark.skipif(
@@ -14,9 +17,52 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_openai_provider_is_constructible_with_opt_in_credentials() -> None:
-    """Network calls belong in a separately enabled smoke suite."""
-    provider = OpenAIDefinitionProvider()
+def _options() -> ProviderOptionsV1:
+    settings = GenerationSettingsV1.from_environment()
+    return ProviderOptionsV1(
+        model=settings.model,
+        timeout_seconds=settings.timeout_seconds,
+        max_retries=settings.max_retries,
+    )
 
-    assert provider.provider_name == "openai"
-    assert GenerationSettingsV1.from_environment().model
+
+def test_openai_simple_generation_validates_against_canonical_model() -> None:
+    provider = OpenAIDefinitionProvider()
+    schema = compile_openai_definition_schema()
+    prompt = """
+You produce only a StatblockDefinitionV1 JSON object for D&D 5e 2024.
+Create one Medium humanoid named 'Gate Scout' with CR 1, walking speed 30 feet,
+Strength 12 Dexterity 14 Constitution 12 Intelligence 10 Wisdom 12 Charisma 10,
+one simple melee attack, and no outer envelope or server metadata.
+definition.ruleset must be {"system":"dnd5e","edition":"2024","house_ruleset_id":null}.
+"""
+    outcome = provider.generate_definition(prompt=prompt, schema=schema, options=_options())
+
+    assert outcome.kind is ProviderOutcomeKind.success
+    assert outcome.payload is not None
+    definition = StatblockDefinitionV1.model_validate(outcome.payload)
+    dumped = definition.model_dump(mode="json")
+    assert "candidate_id" not in dumped
+    assert "created_at" not in dumped
+    assert definition.ruleset.edition.value == "2024"
+
+
+def test_openai_advanced_generation_validates_against_canonical_model() -> None:
+    provider = OpenAIDefinitionProvider()
+    schema = compile_openai_definition_schema()
+    prompt = """
+You produce only a StatblockDefinitionV1 JSON object for D&D 5e 2024.
+Create one Large dragon named 'Ashen Coil' with CR 10, legendary actions using a
+legendary_actions resource pool, flight, and at least one recharge breath weapon.
+Do not emit candidate IDs, digests, timestamps, or provenance.
+definition.ruleset must be {"system":"dnd5e","edition":"2024","house_ruleset_id":null}.
+"""
+    outcome = provider.generate_definition(prompt=prompt, schema=schema, options=_options())
+
+    assert outcome.kind is ProviderOutcomeKind.success
+    assert outcome.payload is not None
+    definition = StatblockDefinitionV1.model_validate(outcome.payload)
+    assert definition.identity.name
+    assert any(pool.key == "legendary_actions" for pool in definition.resources) or any(
+        element.section.value == "legendary_action" for element in definition.rule_elements
+    )

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -1,56 +1,148 @@
+from __future__ import annotations
+
+import copy
 from datetime import datetime, timezone
+
+import pytest
 
 from statblocks_v1.application.commands import (
     AssetOptionsV1,
     CallerProvenanceV1,
+    EncounterContextV1,
     GenerateStatblockCommandV1,
+    GenerationIntentV1,
+    ReviseStatblockCommandV1,
     SourceSnapshotV1,
 )
-from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1
+from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1, _digest_text
 from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
+from statblocks_v1.application.repositories import CreateStatblockCommand
+from statblocks_v1.application.resolvers import PersistenceDefinitionResolver
 from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.domain.errors import InternalServiceMisconfiguredError, RevisionNotFoundError
 from statblocks_v1.domain.profiles import RulesetRef
+from statblocks_v1.domain.receipts import ValidationStatus
+from statblocks_v1.domain.resources import ExactRevisionLocatorV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.infrastructure.fake_provider import FakeDefinitionProvider
-from statblocks_v1.infrastructure.memory_repositories import InMemoryCandidateRepository
+from statblocks_v1.infrastructure.memory_repositories import (
+    DeterministicIdFactory,
+    InMemoryCandidateRepository,
+    InMemoryStatblockPersistenceRepository,
+)
 
 
-def _command() -> GenerateStatblockCommandV1:
-    return GenerateStatblockCommandV1(
+def _command(**overrides) -> GenerateStatblockCommandV1:
+    base = dict(
         request_id="req_generation",
         ruleset=RulesetRef(system="dnd5e", edition="2024"),
         source=SourceSnapshotV1(name_hint="Fixture Bruiser", description="A reliable test creature."),
-        caller=CallerProvenanceV1(caller_scope="tests"),
+        caller=CallerProvenanceV1(caller_scope="tests", actor="unit"),
     )
+    base.update(overrides)
+    return GenerateStatblockCommandV1(**base)
 
 
-def _service(payload, *, candidate_id="cand_1", asset_generator=None) -> GenerationServiceV1:
+def _service(
+    payload,
+    *,
+    candidate_id="cand_1",
+    asset_generator=None,
+    definition_resolver=None,
+    candidates=None,
+) -> GenerationServiceV1:
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     return GenerationServiceV1(
         provider=FakeDefinitionProvider(payload),
-        candidates=InMemoryCandidateRepository(clock=lambda: now),
+        candidates=candidates or InMemoryCandidateRepository(clock=lambda: now),
         settings=GenerationSettingsV1("test-model", 1, 0, 60),
         clock=lambda: now,
         candidate_id_factory=lambda: candidate_id,
         asset_generator=asset_generator,
+        definition_resolver=definition_resolver,
     )
 
 
 def test_generation_persists_valid_candidate(load_fixture) -> None:
-    result = _service(load_fixture("simple_bruiser")).generate(_command())
+    candidates = InMemoryCandidateRepository(
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+    result = _service(load_fixture("simple_bruiser"), candidates=candidates).generate(_command())
 
+    assert not isinstance(result, GenerationFailureV1)
     assert result.candidate_id == "cand_1"
     assert result.generation_receipt.model == "test-model"
-    assert result.generation_receipt.source_description_digest.startswith("sha256:")
-    assert result.validation_receipt.is_persistence_ready
+    assert result.generation_receipt.caller_scope == "tests"
+    assert result.generation_receipt.actor == "unit"
+    assert result.generation_receipt.source_description_digest == _digest_text(
+        "A reliable test creature."
+    )
+    assert result.validation_receipt.status is ValidationStatus.valid
+    assert candidates.get("cand_1").candidate_id == "cand_1"
 
 
-def test_provider_outcome_is_typed_failure() -> None:
-    result = _service(
-        ProviderOutcomeV1(ProviderOutcomeKind.refusal, message="no")
-    ).generate(_command())
+def test_advanced_fixture_generation_persists(load_fixture) -> None:
+    result = _service(load_fixture("legendary_creature"), candidate_id="cand_adv").generate(
+        _command(source=SourceSnapshotV1(name_hint="Legend", description="A mythic threat."))
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert result.candidate_id == "cand_adv"
+    assert result.definition.identity.name
+
+
+def test_warning_bearing_candidate_is_persisted(load_fixture) -> None:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    payload["rule_elements"][0]["rules_text"] = (
+        "Melee Weapon Attack: +99 to hit, reach 10 ft., one target. "
+        "Hit: 11 (2d8 + 2) bludgeoning damage."
+    )
+    result = _service(payload).generate(_command())
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert result.validation_receipt.status is ValidationStatus.warnings
+    assert any(
+        issue.code == "RULES_TEXT_ATTACK_BONUS_MISMATCH"
+        for issue in result.validation_receipt.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        (ProviderOutcomeKind.refusal, "provider_refusal"),
+        (ProviderOutcomeKind.incomplete, "provider_incomplete"),
+        (ProviderOutcomeKind.timeout, "provider_timeout"),
+        (ProviderOutcomeKind.rate_limit, "provider_rate_limit"),
+        (ProviderOutcomeKind.failure, "provider_failure"),
+    ],
+)
+def test_provider_outcomes_are_typed_failures(kind, expected) -> None:
+    result = _service(ProviderOutcomeV1(kind, message="no")).generate(_command())
 
     assert isinstance(result, GenerationFailureV1)
-    assert result.kind == "provider_refusal"
+    assert result.kind == expected
+
+
+def test_provider_exception_is_typed_failure(load_fixture) -> None:
+    class ExplodingProvider:
+        provider_name = "boom"
+
+        def generate_definition(self, **kwargs):
+            raise RuntimeError("sdk exploded")
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    service = GenerationServiceV1(
+        provider=ExplodingProvider(),
+        candidates=InMemoryCandidateRepository(clock=lambda: now),
+        settings=GenerationSettingsV1("test-model", 1, 0, 60),
+        clock=lambda: now,
+        candidate_id_factory=lambda: "cand_x",
+    )
+    result = service.generate(_command())
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "provider_failure"
 
 
 def test_reference_invalid_definition_is_not_persisted(load_fixture) -> None:
@@ -60,16 +152,169 @@ def test_reference_invalid_definition_is_not_persisted(load_fixture) -> None:
     assert result.kind == "definition_invalid"
 
 
+def test_ruleset_mismatch_is_rejected(load_fixture) -> None:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    payload["ruleset"]["edition"] = "2014"
+    result = _service(payload).generate(_command(ruleset=RulesetRef(system="dnd5e", edition="2024")))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "ruleset_mismatch"
+
+
+def test_caller_source_digest_must_match_description() -> None:
+    result = _service({}).generate(
+        _command(
+            source=SourceSnapshotV1(
+                name_hint="Fixture Bruiser",
+                description="A reliable test creature.",
+                description_digest="sha256:" + ("0" * 64),
+            )
+        )
+    )
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "source_digest_mismatch"
+
+
+def test_verified_source_digest_is_stored(load_fixture) -> None:
+    description = "A reliable test creature."
+    digest = _digest_text(description)
+    result = _service(load_fixture("simple_bruiser")).generate(
+        _command(source=SourceSnapshotV1(name_hint="Fixture Bruiser", description=description, description_digest=digest))
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert result.generation_receipt.source_description_digest == digest
+
+
 def test_asset_failure_preserves_valid_candidate(load_fixture) -> None:
     class FailingAssets:
         def generate(self, brief):
             raise RuntimeError("image unavailable")
 
-    command = _command().model_copy(
-        update={"asset_options": AssetOptionsV1(generate_images=True)}
-    )
+    command = _command(asset_options=AssetOptionsV1(generate_images=True))
     result = _service(load_fixture("simple_bruiser"), asset_generator=FailingAssets()).generate(command)
 
-    assert result.candidate_id == "cand_1"
+    assert not isinstance(result, GenerationFailureV1)
     assert result.assets == []
     assert result.asset_warnings
+
+
+def test_requested_assets_without_generator_warn(load_fixture) -> None:
+    command = _command(asset_options=AssetOptionsV1(generate_images=True))
+    result = _service(load_fixture("simple_bruiser")).generate(command)
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert result.assets == []
+    assert any("no asset generator is configured" in warning for warning in result.asset_warnings)
+
+
+def test_revision_from_definition_preserves_keys(load_fixture) -> None:
+    source = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    revised = source.model_copy(deep=True)
+    result = _service(revised.model_dump(mode="json")).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_revise",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["Keep the club attack"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_definition=source,
+            intent=GenerationIntentV1(must_include=["club"]),
+            context=EncounterContextV1(terrain_notes=["gate"]),
+            preserve_element_keys=True,
+        )
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert {element.key for element in result.definition.rule_elements} == {
+        element.key for element in source.rule_elements
+    }
+
+
+def test_revision_key_change_warns_when_preserve_enabled(load_fixture) -> None:
+    source = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    revised_payload = source.model_dump(mode="json")
+    revised_payload["rule_elements"][0]["key"] = "renamed_club"
+    result = _service(revised_payload).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_revise_keys",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["Rename the attack key"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_definition=source,
+            preserve_element_keys=True,
+        )
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert any(issue.code == "ELEMENT_KEY_CHANGED" for issue in result.validation_receipt.issues)
+
+
+def test_revision_from_exact_locator(load_fixture) -> None:
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    persistence = InMemoryStatblockPersistenceRepository(
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc),
+        id_factory=DeterministicIdFactory(),
+    )
+    statblock, revision = persistence.create_statblock(
+        CreateStatblockCommand(
+            caller_scope="tests",
+            idempotency_key="create-revision-source",
+            definition=definition,
+            created_by="tests",
+        )
+    )
+    locator = ExactRevisionLocatorV1(
+        statblock_id=statblock.statblock_id, revision_id=revision.revision_id
+    )
+    result = _service(
+        definition.model_dump(mode="json"),
+        definition_resolver=PersistenceDefinitionResolver(persistence),
+    ).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_locate",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["Tighten the club damage"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_locator=locator,
+        )
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert result.source_locator == locator
+    assert result.generation_receipt.source_locator == locator
+
+
+def test_revision_resolver_errors_are_typed(load_fixture) -> None:
+    class BrokenResolver:
+        def resolve(self, locator):
+            raise RevisionNotFoundError(locator.revision_id)
+
+    result = _service(load_fixture("simple_bruiser"), definition_resolver=BrokenResolver()).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_missing",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["noop"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_locator=ExactRevisionLocatorV1(statblock_id="sb_1", revision_id="rev_missing"),
+        )
+    )
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "revision_not_found"
+
+
+def test_settings_resolve_in_repo_model_policy(monkeypatch) -> None:
+    monkeypatch.delenv("STATBLOCKS_V1_OPENAI_MODEL", raising=False)
+    settings = GenerationSettingsV1.from_environment()
+    assert settings.model == "gpt-5.4-nano"
+
+
+def test_settings_fail_closed_without_policy(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("STATBLOCKS_V1_OPENAI_MODEL", raising=False)
+    monkeypatch.setattr(
+        "statblocks_v1.application.settings._REPO_ROOT",
+        tmp_path,
+    )
+    with pytest.raises(InternalServiceMisconfiguredError):
+        GenerationSettingsV1.from_environment()

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import math
 from datetime import datetime, timezone
 
 import pytest
@@ -14,15 +15,21 @@ from statblocks_v1.application.commands import (
     ReviseStatblockCommandV1,
     SourceSnapshotV1,
 )
-from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1, _digest_text
+from statblocks_v1.application.generation import (
+    KEY_PRESERVATION_PASS_VERSION,
+    GenerationFailureV1,
+    GenerationServiceV1,
+    _digest_text,
+)
 from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
 from statblocks_v1.application.repositories import CreateStatblockCommand
 from statblocks_v1.application.resolvers import PersistenceDefinitionResolver
 from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import InternalServiceMisconfiguredError, RevisionNotFoundError
 from statblocks_v1.domain.profiles import RulesetRef
 from statblocks_v1.domain.receipts import ValidationStatus
-from statblocks_v1.domain.resources import ExactRevisionLocatorV1
+from statblocks_v1.domain.resources import AssetWarningCode, ExactRevisionLocatorV1
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.infrastructure.fake_provider import FakeDefinitionProvider
 from statblocks_v1.infrastructure.memory_repositories import (
@@ -197,7 +204,11 @@ def test_asset_failure_preserves_valid_candidate(load_fixture) -> None:
 
     assert not isinstance(result, GenerationFailureV1)
     assert result.assets == []
-    assert result.asset_warnings
+    assert [warning.code for warning in result.asset_warnings] == [
+        AssetWarningCode.asset_generation_failed
+    ]
+    assert result.asset_brief is not None
+    assert result.asset_brief["prompt"] == "A reliable test creature."
 
 
 def test_requested_assets_without_generator_warn(load_fixture) -> None:
@@ -206,7 +217,49 @@ def test_requested_assets_without_generator_warn(load_fixture) -> None:
 
     assert not isinstance(result, GenerationFailureV1)
     assert result.assets == []
-    assert any("no asset generator is configured" in warning for warning in result.asset_warnings)
+    assert [warning.code for warning in result.asset_warnings] == [
+        AssetWarningCode.asset_generator_unconfigured
+    ]
+    assert result.asset_brief is not None
+
+
+def test_generate_images_persists_effective_brief_without_description_brief(load_fixture) -> None:
+    class CapturingAssets:
+        def __init__(self) -> None:
+            self.brief = None
+
+        def generate(self, brief):
+            self.brief = brief
+            return [{"role": "portrait", "url": "https://example.test/p.png"}]
+
+    assets = CapturingAssets()
+    command = _command(
+        asset_options=AssetOptionsV1(generate_images=True, include_generation_brief=False)
+    )
+    result = _service(load_fixture("simple_bruiser"), asset_generator=assets).generate(command)
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert assets.brief is not None
+    assert result.asset_brief == assets.brief.model_dump(mode="json")
+    assert result.asset_brief["prompt"] == result.definition.identity.name
+    assert result.asset_warnings == []
+
+
+def test_typed_asset_warnings_round_trip_through_candidate_repository(load_fixture) -> None:
+    candidates = InMemoryCandidateRepository(
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+    command = _command(asset_options=AssetOptionsV1(generate_images=True))
+    created = _service(
+        load_fixture("simple_bruiser"), candidates=candidates, candidate_id="cand_warn"
+    ).generate(command)
+
+    assert not isinstance(created, GenerationFailureV1)
+    loaded = candidates.get("cand_warn")
+    assert [warning.code for warning in loaded.asset_warnings] == [
+        AssetWarningCode.asset_generator_unconfigured
+    ]
+    assert loaded.asset_brief == created.asset_brief
 
 
 def test_revision_from_definition_preserves_keys(load_fixture) -> None:
@@ -229,6 +282,59 @@ def test_revision_from_definition_preserves_keys(load_fixture) -> None:
     assert {element.key for element in result.definition.rule_elements} == {
         element.key for element in source.rule_elements
     }
+    assert result.generation_receipt.source_definition_digest == compute_definition_digest(source)
+    assert KEY_PRESERVATION_PASS_VERSION in result.validation_receipt.validator_version
+    assert not any(
+        issue.code.startswith("ELEMENT_KEY_") for issue in result.validation_receipt.issues
+    )
+
+
+def test_inline_revision_source_definition_digests_differ(load_fixture) -> None:
+    source_a = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    source_b_payload = source_a.model_dump(mode="json")
+    source_b_payload["identity"]["name"] = "Fixture Bruiser Variant"
+    source_b = StatblockDefinitionV1.model_validate(source_b_payload)
+    shared_source = SourceSnapshotV1(
+        name_hint="Shared",
+        description="Same authored prose for both revisions.",
+    )
+
+    result_a = _service(source_a.model_dump(mode="json")).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_a",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["noop"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_definition=source_a,
+            source=shared_source,
+        )
+    )
+    result_b = _service(source_b.model_dump(mode="json"), candidate_id="cand_b").revise(
+        ReviseStatblockCommandV1(
+            request_id="req_b",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["noop"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_definition=source_b,
+            source=shared_source,
+        )
+    )
+
+    assert not isinstance(result_a, GenerationFailureV1)
+    assert not isinstance(result_b, GenerationFailureV1)
+    assert result_a.generation_receipt.source_description_digest == (
+        result_b.generation_receipt.source_description_digest
+    )
+    assert result_a.generation_receipt.source_definition_digest == compute_definition_digest(
+        source_a
+    )
+    assert result_b.generation_receipt.source_definition_digest == compute_definition_digest(
+        source_b
+    )
+    assert (
+        result_a.generation_receipt.source_definition_digest
+        != result_b.generation_receipt.source_definition_digest
+    )
 
 
 def test_revision_key_change_warns_when_preserve_enabled(load_fixture) -> None:
@@ -248,6 +354,57 @@ def test_revision_key_change_warns_when_preserve_enabled(load_fixture) -> None:
 
     assert not isinstance(result, GenerationFailureV1)
     assert any(issue.code == "ELEMENT_KEY_CHANGED" for issue in result.validation_receipt.issues)
+
+
+def test_revision_key_repurposed_warns_when_preserve_enabled(load_fixture) -> None:
+    source = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    revised_payload = source.model_dump(mode="json")
+    original_key = revised_payload["rule_elements"][0]["key"]
+    revised_payload["rule_elements"][0]["name"] = "Fire Breath"
+    revised_payload["rule_elements"][0]["key"] = original_key
+    result = _service(revised_payload).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_revise_repurpose",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["Replace the club with fire breath but keep the key"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_definition=source,
+            preserve_element_keys=True,
+        )
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    codes = {issue.code for issue in result.validation_receipt.issues}
+    assert "ELEMENT_KEY_REPURPOSED" in codes
+    assert "ELEMENT_KEY_DROPPED" not in codes
+
+
+def test_revision_duplicate_identity_is_ambiguous_not_misattributed(load_fixture) -> None:
+    source = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    source_payload = source.model_dump(mode="json")
+    duplicate = copy.deepcopy(source_payload["rule_elements"][0])
+    duplicate["key"] = "club_duplicate"
+    source_payload["rule_elements"].append(duplicate)
+    source_with_dupes = StatblockDefinitionV1.model_validate(source_payload)
+
+    revised_payload = source_with_dupes.model_dump(mode="json")
+    revised_payload["rule_elements"][0]["key"] = "renamed_first"
+    revised_payload["rule_elements"][1]["key"] = "renamed_second"
+    result = _service(revised_payload).revise(
+        ReviseStatblockCommandV1(
+            request_id="req_ambiguous",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            revision_instructions=["Rename duplicate clubs"],
+            caller=CallerProvenanceV1(caller_scope="tests"),
+            source_definition=source_with_dupes,
+            preserve_element_keys=True,
+        )
+    )
+
+    assert not isinstance(result, GenerationFailureV1)
+    codes = [issue.code for issue in result.validation_receipt.issues]
+    assert "ELEMENT_KEY_IDENTITY_AMBIGUOUS" in codes
+    assert "ELEMENT_KEY_CHANGED" not in codes
 
 
 def test_revision_from_exact_locator(load_fixture) -> None:
@@ -283,6 +440,10 @@ def test_revision_from_exact_locator(load_fixture) -> None:
     assert not isinstance(result, GenerationFailureV1)
     assert result.source_locator == locator
     assert result.generation_receipt.source_locator == locator
+    assert result.generation_receipt.source_definition_digest == revision.definition_digest
+    assert result.generation_receipt.source_definition_digest == compute_definition_digest(
+        definition
+    )
 
 
 def test_revision_resolver_errors_are_typed(load_fixture) -> None:
@@ -318,3 +479,36 @@ def test_settings_fail_closed_without_policy(monkeypatch, tmp_path) -> None:
     )
     with pytest.raises(InternalServiceMisconfiguredError):
         GenerationSettingsV1.from_environment()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("STATBLOCKS_V1_OPENAI_TIMEOUT_SECONDS", "garbage"),
+        ("STATBLOCKS_V1_OPENAI_MAX_RETRIES", "1.5"),
+        ("STATBLOCKS_V1_CANDIDATE_TTL_SECONDS", "nope"),
+    ],
+)
+def test_settings_malformed_env_is_typed(monkeypatch, env_name, env_value) -> None:
+    monkeypatch.setenv("STATBLOCKS_V1_OPENAI_MODEL", "test-model")
+    monkeypatch.setenv(env_name, env_value)
+    with pytest.raises(InternalServiceMisconfiguredError, match="malformed"):
+        GenerationSettingsV1.from_environment()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"model": "", "timeout_seconds": 1.0, "max_retries": 0, "candidate_ttl_seconds": 60}, "MODEL"),
+        ({"model": "m", "timeout_seconds": 0.0, "max_retries": 0, "candidate_ttl_seconds": 60}, "TIMEOUT"),
+        ({"model": "m", "timeout_seconds": -1.0, "max_retries": 0, "candidate_ttl_seconds": 60}, "TIMEOUT"),
+        ({"model": "m", "timeout_seconds": math.nan, "max_retries": 0, "candidate_ttl_seconds": 60}, "TIMEOUT"),
+        ({"model": "m", "timeout_seconds": math.inf, "max_retries": 0, "candidate_ttl_seconds": 60}, "TIMEOUT"),
+        ({"model": "m", "timeout_seconds": 1.0, "max_retries": -1, "candidate_ttl_seconds": 60}, "RETRIES"),
+        ({"model": "m", "timeout_seconds": 1.0, "max_retries": 0, "candidate_ttl_seconds": 0}, "TTL"),
+        ({"model": "m", "timeout_seconds": 1.0, "max_retries": 0, "candidate_ttl_seconds": -5}, "TTL"),
+    ],
+)
+def test_settings_direct_construction_fails_closed(kwargs, match) -> None:
+    with pytest.raises(InternalServiceMisconfiguredError, match=match):
+        GenerationSettingsV1(**kwargs)

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import math
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 import pytest
@@ -27,7 +29,7 @@ from statblocks_v1.application.resolvers import PersistenceDefinitionResolver
 from statblocks_v1.application.settings import GenerationSettingsV1
 from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import InternalServiceMisconfiguredError, RevisionNotFoundError
-from statblocks_v1.domain.profiles import RulesetRef
+from statblocks_v1.domain.profiles import RulesetEdition, RulesetRef
 from statblocks_v1.domain.receipts import ValidationStatus
 from statblocks_v1.domain.resources import AssetWarningCode, ExactRevisionLocatorV1
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
@@ -405,6 +407,100 @@ def test_revision_duplicate_identity_is_ambiguous_not_misattributed(load_fixture
     codes = [issue.code for issue in result.validation_receipt.issues]
     assert "ELEMENT_KEY_IDENTITY_AMBIGUOUS" in codes
     assert "ELEMENT_KEY_CHANGED" not in codes
+
+
+def test_concurrent_command_mutation_cannot_alter_pinned_revise_intent(load_fixture) -> None:
+    source = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    expected_digest = compute_definition_digest(source)
+    persistence = InMemoryStatblockPersistenceRepository(
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc),
+        id_factory=DeterministicIdFactory(),
+    )
+    statblock, revision = persistence.create_statblock(
+        CreateStatblockCommand(
+            caller_scope="tests",
+            idempotency_key="pin-revision-source",
+            definition=source,
+            created_by="tests",
+        )
+    )
+    locator = ExactRevisionLocatorV1(
+        statblock_id=statblock.statblock_id, revision_id=revision.revision_id
+    )
+    command = ReviseStatblockCommandV1(
+        request_id="req_pinned",
+        ruleset=RulesetRef(system="dnd5e", edition="2024"),
+        revision_instructions=["Keep the club"],
+        caller=CallerProvenanceV1(caller_scope="tests", actor="original"),
+        source_locator=locator,
+        source=SourceSnapshotV1(
+            name_hint="Pinned",
+            description="Pinned revision description.",
+        ),
+        asset_options=AssetOptionsV1(generate_images=True, include_generation_brief=True),
+        preserve_element_keys=True,
+    )
+
+    entered = threading.Event()
+    release = threading.Event()
+    payload = source.model_dump(mode="json")
+
+    def blocking_callback(prompt, schema, options):
+        entered.set()
+        assert release.wait(timeout=2)
+        return ProviderOutcomeV1.succeeded(payload)
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    candidates = InMemoryCandidateRepository(clock=lambda: now)
+    service = GenerationServiceV1(
+        provider=FakeDefinitionProvider({}, callback=blocking_callback),
+        candidates=candidates,
+        settings=GenerationSettingsV1("test-model", 1, 0, 60),
+        clock=lambda: now,
+        candidate_id_factory=lambda: "cand_pinned",
+        definition_resolver=PersistenceDefinitionResolver(persistence),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(service.revise, command)
+        assert entered.wait(timeout=2)
+        # Mutate every caller-owned field while the provider is blocked.
+        command.request_id = "req_hijacked"
+        command.ruleset.edition = RulesetEdition.edition_2014
+        command.caller.caller_scope = "hijacked"
+        command.caller.actor = "mutated"
+        command.source.description = "Mutated description that must not affect digests."
+        command.asset_options.generate_images = False
+        command.preserve_element_keys = False
+        command.source_locator = ExactRevisionLocatorV1(
+            statblock_id="sb_hijacked01", revision_id="rev_hijacked01"
+        )
+        command.revision_instructions[:] = ["Hijacked instructions"]
+        release.set()
+        result = future.result(timeout=2)
+
+    assert not isinstance(result, GenerationFailureV1)
+    assert result.generation_receipt.request_id == "req_pinned"
+    assert result.generation_receipt.caller_scope == "tests"
+    assert result.generation_receipt.actor == "original"
+    assert result.generation_receipt.source_definition_digest == expected_digest
+    assert result.generation_receipt.source_description_digest == _digest_text(
+        "Pinned revision description."
+    )
+    assert result.generation_receipt.source_locator == locator
+    assert result.source_locator == locator
+    assert result.asset_brief is not None
+    assert result.asset_brief["prompt"] == "Pinned revision description."
+    assert [warning.code for warning in result.asset_warnings] == [
+        AssetWarningCode.asset_generator_unconfigured
+    ]
+    assert KEY_PRESERVATION_PASS_VERSION in result.validation_receipt.validator_version
+
+    result.generation_receipt.caller_scope = "returned-mutated"
+    stored = candidates.get("cand_pinned")
+    assert stored.generation_receipt.caller_scope == "tests"
+    assert stored.generation_receipt.source_definition_digest == expected_digest
+    assert stored.generation_receipt.source_locator == locator
 
 
 def test_revision_from_exact_locator(load_fixture) -> None:

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timezone
+
+from statblocks_v1.application.commands import (
+    AssetOptionsV1,
+    CallerProvenanceV1,
+    GenerateStatblockCommandV1,
+    SourceSnapshotV1,
+)
+from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1
+from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
+from statblocks_v1.application.settings import GenerationSettingsV1
+from statblocks_v1.domain.profiles import RulesetRef
+from statblocks_v1.infrastructure.fake_provider import FakeDefinitionProvider
+from statblocks_v1.infrastructure.memory_repositories import InMemoryCandidateRepository
+
+
+def _command() -> GenerateStatblockCommandV1:
+    return GenerateStatblockCommandV1(
+        request_id="req_generation",
+        ruleset=RulesetRef(system="dnd5e", edition="2024"),
+        source=SourceSnapshotV1(name_hint="Fixture Bruiser", description="A reliable test creature."),
+        caller=CallerProvenanceV1(caller_scope="tests"),
+    )
+
+
+def _service(payload, *, candidate_id="cand_1", asset_generator=None) -> GenerationServiceV1:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return GenerationServiceV1(
+        provider=FakeDefinitionProvider(payload),
+        candidates=InMemoryCandidateRepository(clock=lambda: now),
+        settings=GenerationSettingsV1("test-model", 1, 0, 60),
+        clock=lambda: now,
+        candidate_id_factory=lambda: candidate_id,
+        asset_generator=asset_generator,
+    )
+
+
+def test_generation_persists_valid_candidate(load_fixture) -> None:
+    result = _service(load_fixture("simple_bruiser")).generate(_command())
+
+    assert result.candidate_id == "cand_1"
+    assert result.generation_receipt.model == "test-model"
+    assert result.generation_receipt.source_description_digest.startswith("sha256:")
+    assert result.validation_receipt.is_persistence_ready
+
+
+def test_provider_outcome_is_typed_failure() -> None:
+    result = _service(
+        ProviderOutcomeV1(ProviderOutcomeKind.refusal, message="no")
+    ).generate(_command())
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "provider_refusal"
+
+
+def test_reference_invalid_definition_is_not_persisted(load_fixture) -> None:
+    result = _service(load_fixture("dangling_multiattack_ref")).generate(_command())
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "definition_invalid"
+
+
+def test_asset_failure_preserves_valid_candidate(load_fixture) -> None:
+    class FailingAssets:
+        def generate(self, brief):
+            raise RuntimeError("image unavailable")
+
+    command = _command().model_copy(
+        update={"asset_options": AssetOptionsV1(generate_images=True)}
+    )
+    result = _service(load_fixture("simple_bruiser"), asset_generator=FailingAssets()).generate(command)
+
+    assert result.candidate_id == "cand_1"
+    assert result.assets == []
+    assert result.asset_warnings

--- a/tests/statblocks_v1/test_health.py
+++ b/tests/statblocks_v1/test_health.py
@@ -253,8 +253,8 @@ def test_minimal_lane_excludes_full_server_dependencies() -> None:
     assert "ok" in completed.stdout
 
 
-def test_package_source_does_not_construct_firebase_or_openai() -> None:
-    """Static guard: foundation code never constructs Firebase/OpenAI clients."""
+def test_inner_layers_do_not_construct_firebase_or_openai() -> None:
+    """Static guard: only infrastructure adapters may construct external clients."""
     forbidden_tokens = (
         "OpenAI(",
         "firebase_admin",
@@ -262,16 +262,19 @@ def test_package_source_does_not_construct_firebase_or_openai() -> None:
         "StatBlockDetails",
         "statblockgenerator",
     )
-    for path in PACKAGE_ROOT.rglob("*.py"):
-        source = path.read_text()
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                assert node.func.id != "OpenAI", f"{path} constructs OpenAI"
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-                assert node.func.attr != "OpenAI", f"{path} constructs OpenAI"
-        for token in forbidden_tokens:
-            assert token not in source, f"{path} contains forbidden token {token!r}"
+    protected_roots = (PACKAGE_ROOT / "domain", PACKAGE_ROOT / "application", PACKAGE_ROOT / "api")
+    for root in protected_roots:
+        for path in root.rglob("*.py"):
+            # Infrastructure owns concrete provider SDK construction.
+            source = path.read_text()
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                    assert node.func.id != "OpenAI", f"{path} constructs OpenAI"
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                    assert node.func.attr != "OpenAI", f"{path} constructs OpenAI"
+            for token in forbidden_tokens:
+                assert token not in source, f"{path} contains forbidden token {token!r}"
 
 
 def test_openapi_declares_typed_auth_error_responses(client: TestClient) -> None:

--- a/tests/statblocks_v1/test_import_boundaries.py
+++ b/tests/statblocks_v1/test_import_boundaries.py
@@ -48,6 +48,7 @@ STDLIB_AND_TYPING_ROOTS = {
     "unicodedata",
     "pathlib",
     "copy",
+    "time",
 }
 
 FORBIDDEN_LEGACY = (

--- a/tests/statblocks_v1/test_prompt_builder.py
+++ b/tests/statblocks_v1/test_prompt_builder.py
@@ -1,0 +1,23 @@
+from statblocks_v1.application.commands import (
+    CallerProvenanceV1,
+    GenerateStatblockCommandV1,
+    SourceSnapshotV1,
+)
+from statblocks_v1.application.prompts import PROMPT_VERSION, build_generation_prompt
+from statblocks_v1.domain.profiles import RulesetRef
+
+
+def test_generation_prompt_is_versioned_definition_only() -> None:
+    prompt = build_generation_prompt(
+        GenerateStatblockCommandV1(
+            request_id="req_prompt",
+            ruleset=RulesetRef(system="dnd5e", edition="2024"),
+            source=SourceSnapshotV1(name_hint="Gate Warden", description="Guards a narrow gate."),
+            caller=CallerProvenanceV1(caller_scope="test"),
+        )
+    )
+
+    assert PROMPT_VERSION == "statblock-generation-prompt-v1"
+    assert "2024 D&D 5e" in prompt
+    assert "human_adjudicated" in prompt
+    assert "candidate IDs" in prompt

--- a/tests/statblocks_v1/test_prompt_builder.py
+++ b/tests/statblocks_v1/test_prompt_builder.py
@@ -1,10 +1,18 @@
 from statblocks_v1.application.commands import (
     CallerProvenanceV1,
+    EncounterContextV1,
     GenerateStatblockCommandV1,
+    GenerationIntentV1,
+    ReviseStatblockCommandV1,
     SourceSnapshotV1,
 )
-from statblocks_v1.application.prompts import PROMPT_VERSION, build_generation_prompt
+from statblocks_v1.application.prompts import (
+    PROMPT_VERSION,
+    build_generation_prompt,
+    build_revision_prompt,
+)
 from statblocks_v1.domain.profiles import RulesetRef
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 
 
 def test_generation_prompt_is_versioned_definition_only() -> None:
@@ -14,6 +22,7 @@ def test_generation_prompt_is_versioned_definition_only() -> None:
             ruleset=RulesetRef(system="dnd5e", edition="2024"),
             source=SourceSnapshotV1(name_hint="Gate Warden", description="Guards a narrow gate."),
             caller=CallerProvenanceV1(caller_scope="test"),
+            intent=GenerationIntentV1(must_avoid=["flight"]),
         )
     )
 
@@ -21,3 +30,29 @@ def test_generation_prompt_is_versioned_definition_only() -> None:
     assert "2024 D&D 5e" in prompt
     assert "human_adjudicated" in prompt
     assert "candidate IDs" in prompt
+    assert "must avoid=flight" in prompt
+    assert "definition.ruleset.system" in prompt
+
+
+def test_revision_prompt_includes_intent_context_and_preservation(load_fixture) -> None:
+    source = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    prompt = build_revision_prompt(
+        ReviseStatblockCommandV1(
+            request_id="req_rev_prompt",
+            ruleset=RulesetRef(system="dnd5e", edition="2014"),
+            revision_instructions=["Increase CR"],
+            caller=CallerProvenanceV1(caller_scope="test"),
+            source_definition=source,
+            intent=GenerationIntentV1(target_cr="5", roles=["brute"]),
+            context=EncounterContextV1(party_level=4, terrain_notes=["ruins"]),
+            preserve_element_keys=True,
+        ),
+        source,
+    )
+
+    assert "2014 D&D 5e" in prompt
+    assert "Increase CR" in prompt
+    assert "Preserve existing rule-element local keys" in prompt
+    assert "target CR=5" in prompt
+    assert "roles=brute" in prompt
+    assert "ruins" in prompt

--- a/tests/statblocks_v1/test_schema_compiler.py
+++ b/tests/statblocks_v1/test_schema_compiler.py
@@ -1,0 +1,11 @@
+from statblocks_v1.application.schema_compiler import compile_openai_definition_schema
+
+
+def test_compiler_is_deterministic_and_closes_every_object() -> None:
+    first = compile_openai_definition_schema()
+    second = compile_openai_definition_schema()
+
+    assert first.fingerprint == second.fingerprint
+    assert first.schema == second.schema
+    assert first.schema["additionalProperties"] is False
+    assert "$defs" in first.schema


### PR DESCRIPTION
## Summary
- Provider-independent `GenerationServiceV1` generates/revises `StatblockDefinitionV1` through a typed provider seam, validates in candidate mode, and persists server-owned candidates (no HTTP routes).
- Trust boundaries: ruleset match, verified source digests, server-owned caller provenance, exact `(statblock_id, revision_id)` locators, key-preservation warnings, typed provider/resolver failures, in-repo `MODEL_POLICY.json`.
- Offline fake-provider matrix plus opt-in live OpenAI Structured Outputs smoke tests.

## Test plan
- [x] `./scripts/run_statblocks_v1_tests.sh` (isolated lane)
- [x] Revision from definition and exact locator
- [x] Warning-bearing candidate persistence
- [x] Provider outcome catalog + unexpected provider exceptions
- [x] Ruleset mismatch / source digest mismatch
- [ ] Optional: `RUN_OPENAI_GENERATION_TESTS=1 OPENAI_API_KEY=... ./scripts/run_statblocks_v1_tests.sh -k openai`
