### PR TITLE
feat(statblocks_v1): PR18 immutable revision resource API

### DIFF
--- a/Docs/Plans/HANDOFF-pr18-statblock-v1-revision-resource-api.md
+++ b/Docs/Plans/HANDOFF-pr18-statblock-v1-revision-resource-api.md
@@ -1,6 +1,6 @@
 # HANDOFF — PR18 Statblock v1 revision resource API
 
-**Status:** READY AFTER PR17  
+**Status:** IN REVIEW — rebased onto merged PR17; acceptance trust boundaries sealed  
 **Target repository:** `Drakosfire/DungeonMindServer`  
 **Predecessors:** PR14 trust core, PR15 repositories, PR17 router/error boundary  
 **Successor:** `HANDOFF-pr19-statblock-v1-assets-openapi-consumer-contract.md`
@@ -26,15 +26,15 @@
   only. **Candidate idempotency is deferred** (not implemented) so PR15
   statblock/revision idempotency outcomes remain untouched. Do not assume
   request-id replay for candidates.
-- Candidate lookup is `CandidateRepository.get(candidate_id, now=...)`; async
-  routes call synchronous repositories and generation through `asyncio.to_thread`.
+- Candidate lookup is `CandidateRepository.get(candidate_id, now=...)`; acceptance
+  uses `get_for_acceptance` (ignores workflow expiry, still 404 when missing).
+  Async routes call synchronous repositories through `asyncio.to_thread`.
 - OpenAPI operations: `generate_statblock_candidate_v1`,
   `revise_statblock_candidate_v1`, `validate_statblock_definition_v1`,
   `get_statblock_candidate_v1`. ErrorEnvelopeV1 is declared on failure statuses.
-  No accepted-resource routes exist yet.
-- Tests override `get_generation_service`, `get_candidate_repository`, and
-  `get_clock` with `FakeDefinitionProvider`, `InMemoryCandidateRepository` /
-  `InMemoryStatblockPersistenceRepository`, and deterministic clocks.
+  No accepted-resource routes existed yet before PR18.
+- Tests override `get_generation_service`, `get_candidate_repository`,
+  `get_persistence_repository`, `get_revision_service`, and `get_clock`.
 
 ## 0. Mission
 
@@ -130,6 +130,11 @@ A revision returned immediately after create/append and the same revision return
 - identical provenance and asset bindings;
 - no dependency on current prompt, model, renderer, or latest revision.
 
+Candidate-linked acceptance must also replay after the source candidate document is
+gone (TTL deletion). Idempotency is consulted **before** `get_for_acceptance`, and
+server-owned `provenance.candidate` audit evidence is excluded from the request
+digest (`candidate_id` remains in the digest).
+
 Add a full exact-replay test.
 
 ## 6. Idempotency
@@ -155,12 +160,22 @@ No client-supplied revision ID.
 
 When `candidate_id` is supplied:
 
-- load the server-owned candidate;
-- reject missing/expired candidate only according to documented acceptance policy;
-- record source candidate ID, source definition digest, generation receipt locator/snapshot, and whether accepted definition changed;
-- never replace the submitted accepted definition with candidate content.
+- load the server-owned candidate via `get_for_acceptance`;
+- reject missing candidates with `404 candidate_not_found` on first write;
+- record source candidate ID, source definition digest, generation receipt
+  locator/snapshot, and whether accepted definition changed under
+  `provenance.candidate` (server-owned; never caller-supplied);
+- never replace the submitted accepted definition with candidate content;
+- never accept a free-form caller `provenance` object on the public DTO.
 
-Decide explicitly whether an expired candidate can still be accepted if its record remains available. Recommended: expiration prevents new candidate reads/generation workflow but does not erase server audit data immediately; acceptance policy should be documented and tested.
+Expired candidates may still be accepted while their record remains available.
+Workflow candidate GET returns `410` once expired. After TTL deletes the record,
+same-key acceptance replay returns the original revision without requiring the
+candidate document.
+
+`actor` is acceptance provenance (`accepted_by`) only. Logical-statblock
+`created_by` is the authenticated service identity (`dungeonbuddy`), not the
+caller-asserted actor.
 
 ## 8. Validation failures
 
@@ -249,9 +264,11 @@ PR18 is complete when:
 Before merge, update PR19 with:
 
 - exact OpenAPI operation IDs;
-- final resource/request models;
+- final resource/request models (no free-form provenance spoof surface);
 - asset-binding model;
 - revision locator format;
 - pagination behavior;
-- candidate acceptance/expiration policy;
+- candidate acceptance/expiration policy and same-key replay after TTL;
+- `created_by` = service identity; `actor` = provenance only;
+- PR18 error catalog extension (idempotency/parent/stale/validation/indeterminate);
 - cross-repo fixture suitable for DungeonBuddy client generation.

--- a/Docs/Plans/HANDOFF-pr18-statblock-v1-revision-resource-api.md
+++ b/Docs/Plans/HANDOFF-pr18-statblock-v1-revision-resource-api.md
@@ -135,6 +135,12 @@ gone (TTL deletion). Idempotency is consulted **before** `get_for_acceptance`, a
 server-owned `provenance.candidate` audit evidence is excluded from the request
 digest (`candidate_id` remains in the digest).
 
+Idempotency is also consulted **before** semantic persistence validation.
+Validation and candidate lookup run only when the key is genuinely new, so a
+changed-but-invalid retry yields `409 idempotency_conflict` rather than
+`422 validation_failed`, and exact replay survives future validator-policy
+changes.
+
 Add a full exact-replay test.
 
 ## 6. Idempotency
@@ -146,9 +152,11 @@ Required behavior:
 ```text
 same key + same canonical request
   → return original resource outcome
+    (consult idempotency before persistence validation)
 
 same key + changed definition, parent, or operation metadata
   → 409 typed idempotency conflict
+    (even when the changed payload would fail persistence validation)
 
 concurrent same-key requests
   → one revision only

--- a/Docs/Plans/HANDOFF-pr19-statblock-v1-assets-openapi-consumer-contract.md
+++ b/Docs/Plans/HANDOFF-pr19-statblock-v1-assets-openapi-consumer-contract.md
@@ -6,6 +6,33 @@
 **Predecessor:** PR18 revision resource API  
 **Successor:** `HANDOFF-pr20-statblock-v1-production-hardening-launch.md`
 
+## PR18 predecessor completion notes
+
+- Resource operation IDs are `create_statblock_v1`,
+  `append_statblock_revision_v1`, `get_statblock_v1`,
+  `list_statblock_revisions_v1`, and `get_statblock_revision_v1`.
+- Create returns `{ statblock, revision }`; append and exact read return
+  `StatblockRevisionResourceV1`; list returns `{ revisions }` chronologically.
+  The durable locator is `statblock_id + revision_id`.
+- Write DTOs expose typed acceptance fields only (`change_summary`,
+  `accepted_through`, `actor`, `candidate_id`, `asset_bindings`). There is no
+  free-form caller `provenance` object. Server-owned `provenance.candidate`
+  audit evidence is attached on first write.
+- `created_by` is always the service identity (`dungeonbuddy`). Caller `actor`
+  is stored as provenance `accepted_by` only.
+- Candidate GET returns `410` once expired. Acceptance may still reference an
+  expired candidate while its server-owned record remains available. Same-key
+  create/append replay survives candidate TTL deletion because idempotency is
+  checked before `get_for_acceptance`.
+- PR18 extends the PR17 error map with `idempotency_conflict`,
+  `parent_revision_mismatch`, `stale_parent_revision`, immutable conflicts,
+  `ambiguous_request_payload`, `validation_failed` (with full receipt), and
+  `transaction_indeterminate`. Resource write/read OpenAPI declares the typed
+  failure statuses; no PUT/PATCH/DELETE revision routes exist.
+- Asset bindings are currently caller-supplied revision-envelope dictionaries;
+  they are excluded from the mechanics definition digest. PR19 replaces them
+  with the typed asset contract.
+
 ## 0. Mission
 
 Make the authoritative v1 route cleanly consumable by DungeonBuddy: complete typed asset-reference behavior, deterministic OpenAPI/schema publication, generated consumer types/client, and cross-repository contract tests.

--- a/statblocks_v1/api/dependencies.py
+++ b/statblocks_v1/api/dependencies.py
@@ -27,6 +27,7 @@ from statblocks_v1.application.repositories import (
     CandidateRepository,
     StatblockPersistenceRepository,
 )
+from statblocks_v1.application.revisions import RevisionServiceV1
 from statblocks_v1.domain.errors import (
     InternalServiceMisconfiguredError,
     UnauthorizedInternalClientError,
@@ -45,6 +46,7 @@ Clock = Callable[[], datetime]
 _candidate_repository_factory: Callable[[], CandidateRepository] | None = None
 _persistence_repository_factory: Callable[[], StatblockPersistenceRepository] | None = None
 _generation_service_factory: Callable[[], GenerationServiceV1] | None = None
+_revision_service_factory: Callable[[], RevisionServiceV1] | None = None
 
 
 def configure_candidate_repository_factory(
@@ -66,6 +68,13 @@ def configure_generation_service_factory(
 ) -> None:
     global _generation_service_factory
     _generation_service_factory = factory
+
+
+def configure_revision_service_factory(
+    factory: Callable[[], RevisionServiceV1] | None,
+) -> None:
+    global _revision_service_factory
+    _revision_service_factory = factory
 
 
 async def require_internal_service_auth(
@@ -117,6 +126,17 @@ def get_generation_service() -> GenerationServiceV1:
             InternalServiceMisconfiguredError("Generation service is not configured"),
         )
     return _generation_service_factory()
+
+
+def get_revision_service() -> RevisionServiceV1:
+    if _revision_service_factory is not None:
+        return _revision_service_factory()
+    # Default composition uses already-configured repository factories.
+    return RevisionServiceV1(
+        persistence=get_persistence_repository(),
+        candidates=get_candidate_repository(),
+        clock=get_clock(),
+    )
 
 
 def get_validator() -> Validator:

--- a/statblocks_v1/api/http_errors.py
+++ b/statblocks_v1/api/http_errors.py
@@ -19,13 +19,21 @@ from fastapi.responses import JSONResponse
 from statblocks_v1.api.models import ErrorDetailV1, ErrorEnvelopeV1
 from statblocks_v1.application.generation import GenerationFailureV1
 from statblocks_v1.domain.errors import (
+    AmbiguousRequestPayloadError,
     CandidateExpiredError,
     CandidateNotFoundError,
+    IdempotencyConflictError,
+    ImmutableResourceConflictError,
+    ImmutableRevisionConflictError,
     InternalServiceMisconfiguredError,
+    ParentRevisionMismatchError,
     PersistenceUnavailableError,
+    PersistenceValidationError,
     RevisionNotFoundError,
+    StaleParentRevisionError,
     StatblockNotFoundError,
     StatblockV1Error,
+    TransactionIndeterminateError,
     UnauthorizedInternalClientError,
 )
 
@@ -38,7 +46,15 @@ _DOMAIN_STATUS: dict[type[StatblockV1Error], int] = {
     CandidateExpiredError: 410,
     StatblockNotFoundError: 404,
     RevisionNotFoundError: 404,
+    IdempotencyConflictError: 409,
+    ParentRevisionMismatchError: 409,
+    StaleParentRevisionError: 409,
+    ImmutableResourceConflictError: 409,
+    ImmutableRevisionConflictError: 409,
+    AmbiguousRequestPayloadError: 422,
+    PersistenceValidationError: 422,
     PersistenceUnavailableError: 503,
+    TransactionIndeterminateError: 503,
 }
 
 # Final PR16 GenerationFailureV1.kind → (status, public code, message)

--- a/statblocks_v1/api/models.py
+++ b/statblocks_v1/api/models.py
@@ -14,7 +14,11 @@ from statblocks_v1.application.commands import (
 )
 from statblocks_v1.domain.profiles import RulesetRef
 from statblocks_v1.domain.receipts import ValidationReceiptV1
-from statblocks_v1.domain.resources import ExactRevisionLocatorV1
+from statblocks_v1.domain.resources import (
+    ExactRevisionLocatorV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 
 
@@ -80,3 +84,43 @@ class ValidateDefinitionRequestV1(StrictModel):
 class ValidationResponseV1(StrictModel):
     validation_receipt: ValidationReceiptV1
     definition_digest: str
+
+
+class CreateStatblockRequestV1(StrictModel):
+    """Accept a reviewed definition into a new logical statblock + first revision.
+
+    Free-form ``provenance`` is intentionally absent: callers may supply typed
+    acceptance metadata only. Server-owned candidate audit evidence is attached
+    when ``candidate_id`` is present. ``actor`` is provenance data, not
+    authenticated ownership of ``created_by``.
+    """
+
+    idempotency_key: str = Field(min_length=1)
+    definition: StatblockDefinitionV1
+    candidate_id: str | None = Field(default=None, pattern=r"^cand_[a-z0-9]+$")
+    change_summary: str = Field(min_length=1)
+    actor: str | None = None
+    accepted_through: dict[str, Any] = Field(default_factory=dict)
+    asset_bindings: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class AppendRevisionRequestV1(StrictModel):
+    """Append an immutable revision under compare-and-swap parent semantics."""
+
+    idempotency_key: str = Field(min_length=1)
+    parent_revision_id: str = Field(pattern=r"^rev_[a-z0-9]+$")
+    definition: StatblockDefinitionV1
+    candidate_id: str | None = Field(default=None, pattern=r"^cand_[a-z0-9]+$")
+    change_summary: str = Field(min_length=1)
+    actor: str | None = None
+    accepted_through: dict[str, Any] = Field(default_factory=dict)
+    asset_bindings: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class CreateStatblockResponseV1(StrictModel):
+    statblock: StatblockResourceV1
+    revision: StatblockRevisionResourceV1
+
+
+class RevisionListResponseV1(StrictModel):
+    revisions: list[StatblockRevisionResourceV1]

--- a/statblocks_v1/api/router.py
+++ b/statblocks_v1/api/router.py
@@ -14,14 +14,20 @@ from statblocks_v1.api.dependencies import (
     get_candidate_repository,
     get_clock,
     get_generation_service,
+    get_persistence_repository,
+    get_revision_service,
     get_validator,
     require_internal_service_auth,
 )
 from statblocks_v1.api.http_errors import raise_for_generation_failure
 from statblocks_v1.api.models import (
+    AppendRevisionRequestV1,
+    CreateStatblockRequestV1,
+    CreateStatblockResponseV1,
     ErrorEnvelopeV1,
     GenerateCandidateRequestV1,
     HealthResponseV1,
+    RevisionListResponseV1,
     ReviseCandidateRequestV1,
     ValidateDefinitionRequestV1,
     ValidationResponseV1,
@@ -32,9 +38,17 @@ from statblocks_v1.application.commands import (
     ReviseStatblockCommandV1,
 )
 from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1
-from statblocks_v1.application.repositories import CandidateRepository
+from statblocks_v1.application.repositories import (
+    CandidateRepository,
+    StatblockPersistenceRepository,
+)
+from statblocks_v1.application.revisions import RevisionServiceV1
 from statblocks_v1.domain.receipts import ValidationMode
-from statblocks_v1.domain.resources import GeneratedStatblockCandidateV1
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
 
 _AUTH_ERROR_RESPONSES = {
     401: {"model": ErrorEnvelopeV1, "description": "Missing internal API key"},
@@ -77,6 +91,29 @@ _VALIDATE_ERROR_RESPONSES = {
     422: {"model": ErrorEnvelopeV1, "description": "Invalid request"},
 }
 
+_RESOURCE_WRITE_ERROR_RESPONSES = {
+    **_AUTH_ERROR_RESPONSES,
+    404: {
+        "model": ErrorEnvelopeV1,
+        "description": "Statblock, revision, or acceptance candidate not found",
+    },
+    409: {
+        "model": ErrorEnvelopeV1,
+        "description": (
+            "Idempotency conflict, parent mismatch, stale parent, or immutable ID conflict"
+        ),
+    },
+    422: {
+        "model": ErrorEnvelopeV1,
+        "description": "Request validation or persistence-mode validation failed",
+    },
+}
+
+_RESOURCE_READ_ERROR_RESPONSES = {
+    **_AUTH_ERROR_RESPONSES,
+    404: {"model": ErrorEnvelopeV1, "description": "Statblock or revision not found"},
+}
+
 router = APIRouter(
     prefix="/api/internal/dungeonbuddy/v1",
     tags=["DungeonBuddy Statblocks v1"],
@@ -91,7 +128,7 @@ router = APIRouter(
     responses=_AUTH_ERROR_RESPONSES,
 )
 async def health() -> HealthResponseV1:
-    """Advertise the candidate workflow currently available to DungeonBuddy."""
+    """Advertise the candidate and acceptance workflow available to DungeonBuddy."""
     return HealthResponseV1(
         status="available",
         contract=CONTRACT_NAME,
@@ -101,6 +138,11 @@ async def health() -> HealthResponseV1:
             "candidate_revise",
             "definition_validate",
             "candidate_read",
+            "statblock_create",
+            "statblock_revision_append",
+            "statblock_read",
+            "statblock_revision_list",
+            "statblock_revision_read",
         ],
     )
 
@@ -191,3 +233,103 @@ async def get_candidate(
     clock: Annotated[Clock, Depends(get_clock)],
 ) -> GeneratedStatblockCandidateV1:
     return await asyncio.to_thread(candidates.get, candidate_id, now=clock())
+
+
+@router.post(
+    "/statblocks",
+    response_model=CreateStatblockResponseV1,
+    responses=_RESOURCE_WRITE_ERROR_RESPONSES,
+    operation_id="create_statblock_v1",
+)
+async def create_statblock(
+    request: CreateStatblockRequestV1,
+    service: Annotated[RevisionServiceV1, Depends(get_revision_service)],
+) -> CreateStatblockResponseV1:
+    statblock, revision = await asyncio.to_thread(
+        service.create,
+        idempotency_key=request.idempotency_key,
+        definition=request.definition,
+        change_summary=request.change_summary,
+        accepted_through=request.accepted_through,
+        actor=request.actor,
+        asset_bindings=request.asset_bindings,
+        candidate_id=request.candidate_id,
+    )
+    return CreateStatblockResponseV1(statblock=statblock, revision=revision)
+
+
+@router.post(
+    "/statblocks/{statblock_id}/revisions",
+    response_model=StatblockRevisionResourceV1,
+    responses=_RESOURCE_WRITE_ERROR_RESPONSES,
+    operation_id="append_statblock_revision_v1",
+)
+async def append_revision(
+    statblock_id: str,
+    request: AppendRevisionRequestV1,
+    service: Annotated[RevisionServiceV1, Depends(get_revision_service)],
+) -> StatblockRevisionResourceV1:
+    return await asyncio.to_thread(
+        service.append,
+        statblock_id=statblock_id,
+        parent_revision_id=request.parent_revision_id,
+        idempotency_key=request.idempotency_key,
+        definition=request.definition,
+        change_summary=request.change_summary,
+        accepted_through=request.accepted_through,
+        actor=request.actor,
+        asset_bindings=request.asset_bindings,
+        candidate_id=request.candidate_id,
+    )
+
+
+@router.get(
+    "/statblocks/{statblock_id}",
+    response_model=StatblockResourceV1,
+    responses=_RESOURCE_READ_ERROR_RESPONSES,
+    operation_id="get_statblock_v1",
+)
+async def get_statblock(
+    statblock_id: str,
+    persistence: Annotated[
+        StatblockPersistenceRepository, Depends(get_persistence_repository)
+    ],
+) -> StatblockResourceV1:
+    return await asyncio.to_thread(persistence.get, statblock_id)
+
+
+@router.get(
+    "/statblocks/{statblock_id}/revisions",
+    response_model=RevisionListResponseV1,
+    responses=_RESOURCE_READ_ERROR_RESPONSES,
+    operation_id="list_statblock_revisions_v1",
+)
+async def list_revisions(
+    statblock_id: str,
+    persistence: Annotated[
+        StatblockPersistenceRepository, Depends(get_persistence_repository)
+    ],
+) -> RevisionListResponseV1:
+    revisions = await asyncio.to_thread(persistence.list_for_statblock, statblock_id)
+    return RevisionListResponseV1(
+        revisions=sorted(
+            revisions, key=lambda revision: (revision.created_at, revision.revision_id)
+        )
+    )
+
+
+@router.get(
+    "/statblocks/{statblock_id}/revisions/{revision_id}",
+    response_model=StatblockRevisionResourceV1,
+    responses=_RESOURCE_READ_ERROR_RESPONSES,
+    operation_id="get_statblock_revision_v1",
+)
+async def get_revision(
+    statblock_id: str,
+    revision_id: str,
+    persistence: Annotated[
+        StatblockPersistenceRepository, Depends(get_persistence_repository)
+    ],
+) -> StatblockRevisionResourceV1:
+    """Resolve exactly the locator supplied by the caller; never select latest."""
+    return await asyncio.to_thread(persistence.get_revision, statblock_id, revision_id)

--- a/statblocks_v1/application/repositories.py
+++ b/statblocks_v1/application/repositories.py
@@ -61,9 +61,23 @@ def _normalize_request_payload(value: Any) -> Any:
     return value
 
 
+def _idempotency_provenance(provenance: Mapping[str, Any]) -> dict[str, Any]:
+    """Exclude server-owned candidate audit evidence from the request digest.
+
+    ``candidate_id`` is hashed separately. Replay must not require the live
+    candidate document after Firestore TTL deletion.
+    """
+
+    return {key: value for key, value in provenance.items() if key != "candidate"}
+
+
 class CandidateRepository(Protocol):
     def create(self, candidate: GeneratedStatblockCandidateV1) -> GeneratedStatblockCandidateV1: ...
     def get(self, candidate_id: str, *, now: datetime | None = None) -> GeneratedStatblockCandidateV1: ...
+
+    def get_for_acceptance(self, candidate_id: str) -> GeneratedStatblockCandidateV1:
+        """Load retained candidate audit data without applying workflow expiry."""
+        ...
 
 
 class StatblockRepository(Protocol):
@@ -137,7 +151,7 @@ class CreateStatblockCommand:
                         canonicalize_definition(self._definition)
                     ),
                     "created_by": created_by,
-                    "provenance": self._provenance,
+                    "provenance": _idempotency_provenance(self._provenance),
                     "asset_bindings": self._asset_bindings,
                     "candidate_id": candidate_id,
                 },
@@ -210,7 +224,7 @@ class AppendRevisionCommand:
                     "definition_canonical": str(
                         canonicalize_definition(self._definition)
                     ),
-                    "provenance": self._provenance,
+                    "provenance": _idempotency_provenance(self._provenance),
                     "asset_bindings": self._asset_bindings,
                     "candidate_id": candidate_id,
                 },

--- a/statblocks_v1/application/revisions.py
+++ b/statblocks_v1/application/revisions.py
@@ -29,10 +29,14 @@ SERVICE_CREATED_BY = "dungeonbuddy"
 
 
 class RevisionServiceV1:
-    """Validate and enrich acceptances before the atomic persistence boundary.
+    """Enrich acceptances and gate writes behind durable idempotency.
 
-    Idempotency is consulted before candidate lookup so same-key replay remains
-    available after Firestore TTL deletes the source candidate document.
+    Replay is consulted before persistence validation and candidate lookup so:
+    - same key + same request returns the original outcome even if validator
+      policy later changes;
+    - same key + changed definition/metadata returns ``idempotency_conflict``
+      even when the changed payload would otherwise fail validation.
+    Validation and candidate audit run only for genuinely new keys.
     """
 
     def __init__(
@@ -57,7 +61,6 @@ class RevisionServiceV1:
         asset_bindings: list[dict[str, Any]] | None = None,
         candidate_id: str | None = None,
     ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
-        self._validate_persistence(definition)
         client_provenance = _seal_client_provenance(
             change_summary=change_summary,
             accepted_through=accepted_through,
@@ -76,6 +79,7 @@ class RevisionServiceV1:
         if replayed is not None:
             return replayed
 
+        self._validate_persistence(definition)
         enriched = self._with_candidate_audit(candidate_id, definition, client_provenance)
         return self._persistence.create_statblock(
             CreateStatblockCommand(
@@ -102,7 +106,6 @@ class RevisionServiceV1:
         asset_bindings: list[dict[str, Any]] | None = None,
         candidate_id: str | None = None,
     ) -> StatblockRevisionResourceV1:
-        self._validate_persistence(definition)
         client_provenance = _seal_client_provenance(
             change_summary=change_summary,
             accepted_through=accepted_through,
@@ -122,6 +125,7 @@ class RevisionServiceV1:
         if replayed is not None:
             return replayed
 
+        self._validate_persistence(definition)
         enriched = self._with_candidate_audit(candidate_id, definition, client_provenance)
         return self._persistence.append_revision(
             AppendRevisionCommand(

--- a/statblocks_v1/application/revisions.py
+++ b/statblocks_v1/application/revisions.py
@@ -1,0 +1,224 @@
+"""Application service for immutable logical-statblock revisions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+
+from statblocks_v1.application.repositories import (
+    AppendRevisionCommand,
+    CandidateRepository,
+    CreateStatblockCommand,
+    StatblockPersistenceRepository,
+)
+from statblocks_v1.domain.digests import compute_definition_digest
+from statblocks_v1.domain.errors import IdempotencyConflictError, PersistenceValidationError
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import (
+    GeneratedStatblockCandidateV1,
+    StatblockResourceV1,
+    StatblockRevisionResourceV1,
+)
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.validation import validate_definition
+
+# Service-authenticated caller identity. End-user ``actor`` is provenance only.
+SERVICE_CREATED_BY = "dungeonbuddy"
+
+
+class RevisionServiceV1:
+    """Validate and enrich acceptances before the atomic persistence boundary.
+
+    Idempotency is consulted before candidate lookup so same-key replay remains
+    available after Firestore TTL deletes the source candidate document.
+    """
+
+    def __init__(
+        self,
+        *,
+        persistence: StatblockPersistenceRepository,
+        candidates: CandidateRepository,
+        clock: Callable[[], datetime],
+    ) -> None:
+        self._persistence = persistence
+        self._candidates = candidates
+        self._clock = clock
+
+    def create(
+        self,
+        *,
+        idempotency_key: str,
+        definition: StatblockDefinitionV1,
+        change_summary: str,
+        accepted_through: dict[str, Any] | None = None,
+        actor: str | None = None,
+        asset_bindings: list[dict[str, Any]] | None = None,
+        candidate_id: str | None = None,
+    ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1]:
+        self._validate_persistence(definition)
+        client_provenance = _seal_client_provenance(
+            change_summary=change_summary,
+            accepted_through=accepted_through,
+            actor=actor,
+        )
+        probe = CreateStatblockCommand(
+            caller_scope="dungeonbuddy",
+            idempotency_key=idempotency_key,
+            definition=definition,
+            created_by=SERVICE_CREATED_BY,
+            provenance=client_provenance,
+            asset_bindings=asset_bindings,
+            candidate_id=candidate_id,
+        )
+        replayed = self._replay_create(probe)
+        if replayed is not None:
+            return replayed
+
+        enriched = self._with_candidate_audit(candidate_id, definition, client_provenance)
+        return self._persistence.create_statblock(
+            CreateStatblockCommand(
+                caller_scope="dungeonbuddy",
+                idempotency_key=idempotency_key,
+                definition=definition,
+                created_by=SERVICE_CREATED_BY,
+                provenance=enriched,
+                asset_bindings=asset_bindings,
+                candidate_id=candidate_id,
+            )
+        )
+
+    def append(
+        self,
+        *,
+        statblock_id: str,
+        parent_revision_id: str,
+        idempotency_key: str,
+        definition: StatblockDefinitionV1,
+        change_summary: str,
+        accepted_through: dict[str, Any] | None = None,
+        actor: str | None = None,
+        asset_bindings: list[dict[str, Any]] | None = None,
+        candidate_id: str | None = None,
+    ) -> StatblockRevisionResourceV1:
+        self._validate_persistence(definition)
+        client_provenance = _seal_client_provenance(
+            change_summary=change_summary,
+            accepted_through=accepted_through,
+            actor=actor,
+        )
+        probe = AppendRevisionCommand(
+            caller_scope="dungeonbuddy",
+            idempotency_key=idempotency_key,
+            statblock_id=statblock_id,
+            parent_revision_id=parent_revision_id,
+            definition=definition,
+            provenance=client_provenance,
+            asset_bindings=asset_bindings,
+            candidate_id=candidate_id,
+        )
+        replayed = self._replay_append(probe)
+        if replayed is not None:
+            return replayed
+
+        enriched = self._with_candidate_audit(candidate_id, definition, client_provenance)
+        return self._persistence.append_revision(
+            AppendRevisionCommand(
+                caller_scope="dungeonbuddy",
+                idempotency_key=idempotency_key,
+                statblock_id=statblock_id,
+                parent_revision_id=parent_revision_id,
+                definition=definition,
+                provenance=enriched,
+                asset_bindings=asset_bindings,
+                candidate_id=candidate_id,
+            )
+        )
+
+    def _validate_persistence(self, definition: StatblockDefinitionV1) -> None:
+        receipt = validate_definition(
+            definition, ValidationMode.persistence, validated_at=self._clock()
+        )
+        if not receipt.is_persistence_ready:
+            raise PersistenceValidationError(receipt)
+
+    def _replay_create(
+        self, command: CreateStatblockCommand
+    ) -> tuple[StatblockResourceV1, StatblockRevisionResourceV1] | None:
+        record = self._persistence.get_idempotency(
+            command.caller_scope, "create_statblock", command.idempotency_key
+        )
+        if record is None:
+            return None
+        if record.request_digest != command.request_digest:
+            raise IdempotencyConflictError(command.idempotency_key)
+        return (
+            self._persistence.get(record.outcome.statblock_id),
+            self._persistence.get_revision(
+                record.outcome.statblock_id, record.outcome.revision_id
+            ),
+        )
+
+    def _replay_append(self, command: AppendRevisionCommand) -> StatblockRevisionResourceV1 | None:
+        record = self._persistence.get_idempotency(
+            command.caller_scope, "append_revision", command.idempotency_key
+        )
+        if record is None:
+            return None
+        if record.request_digest != command.request_digest:
+            raise IdempotencyConflictError(command.idempotency_key)
+        return self._persistence.get_revision(
+            record.outcome.statblock_id, record.outcome.revision_id
+        )
+
+    def _with_candidate_audit(
+        self,
+        candidate_id: str | None,
+        accepted_definition: StatblockDefinitionV1,
+        provenance: dict[str, Any],
+    ) -> dict[str, Any]:
+        result = deepcopy(provenance)
+        if candidate_id is None:
+            return result
+        candidate = self._candidates.get_for_acceptance(candidate_id)
+        candidate_digest = candidate.validation_receipt.definition_digest
+        accepted_digest = compute_definition_digest(accepted_definition)
+        result["candidate"] = _candidate_audit(candidate, candidate_digest, accepted_digest)
+        return result
+
+
+def _seal_client_provenance(
+    *,
+    change_summary: str,
+    accepted_through: dict[str, Any] | None,
+    actor: str | None,
+) -> dict[str, Any]:
+    """Build caller provenance from typed fields only (no free-form spoof surface)."""
+
+    sealed: dict[str, Any] = {
+        "change_summary": change_summary,
+        "accepted_through": deepcopy(accepted_through or {}),
+    }
+    if actor:
+        sealed["accepted_by"] = actor
+    return sealed
+
+
+def _candidate_audit(
+    candidate: GeneratedStatblockCandidateV1,
+    source_digest: str,
+    accepted_digest: str,
+) -> dict[str, Any]:
+    """Keep audit evidence even after candidate read expiry."""
+
+    return {
+        "candidate_id": candidate.candidate_id,
+        "source_definition_digest": source_digest,
+        "generation_receipt": (
+            candidate.generation_receipt.model_dump(mode="json")
+            if candidate.generation_receipt
+            else None
+        ),
+        "accepted_definition_changed": source_digest != accepted_digest,
+    }

--- a/statblocks_v1/domain/errors.py
+++ b/statblocks_v1/domain/errors.py
@@ -116,8 +116,18 @@ class AmbiguousRequestPayloadError(StatblockV1Error):
 
 
 class PersistenceValidationError(StatblockV1Error):
-    def __init__(self) -> None:
-        super().__init__("validation_failed", "Definition is not persistence-ready")
+    def __init__(self, receipt: Any | None = None) -> None:
+        details = None
+        if receipt is not None:
+            details = {
+                "validation_receipt": receipt.model_dump(mode="json"),
+                "is_persistence_ready": receipt.is_persistence_ready,
+            }
+        super().__init__(
+            "validation_failed",
+            "Definition is not persistence-ready",
+            details,
+        )
 
 
 class PersistenceUnavailableError(StatblockV1Error):

--- a/statblocks_v1/infrastructure/firestore_repositories.py
+++ b/statblocks_v1/infrastructure/firestore_repositories.py
@@ -74,6 +74,16 @@ class FirestoreCandidateRepository:
             raise CandidateExpiredError(candidate_id)
         return candidate
 
+    def get_for_acceptance(self, candidate_id: str) -> GeneratedStatblockCandidateV1:
+        """Read retained candidate audit data without applying workflow expiry."""
+        try:
+            snapshot = self._client.collection(CANDIDATES_COLLECTION).document(candidate_id).get()
+        except Exception as error:
+            raise PersistenceUnavailableError() from error
+        if not snapshot.exists:
+            raise CandidateNotFoundError(candidate_id)
+        return GeneratedStatblockCandidateV1.model_validate(snapshot.to_dict())
+
 
 class FirestoreStatblockPersistenceRepository:
     """Atomic create/append adapter using Firestore read-write transactions."""

--- a/statblocks_v1/infrastructure/memory_repositories.py
+++ b/statblocks_v1/infrastructure/memory_repositories.py
@@ -76,6 +76,14 @@ class InMemoryCandidateRepository:
                 raise CandidateExpiredError(candidate_id)
             return _copy(candidate)
 
+    def get_for_acceptance(self, candidate_id: str) -> GeneratedStatblockCandidateV1:
+        """Expiry blocks candidate workflow reads, never durable audit acceptance."""
+        with self._lock:
+            candidate = self._candidates.get(candidate_id)
+            if candidate is None:
+                raise CandidateNotFoundError(candidate_id)
+            return _copy(candidate)
+
 
 class InMemoryStatblockPersistenceRepository:
     """One lock models the atomicity expected from the Firestore implementation."""
@@ -286,11 +294,11 @@ class InMemoryStatblockPersistenceRepository:
 def _persistence_material(definition: StatblockDefinitionV1):
     receipt = validate_definition(definition, ValidationMode.persistence)
     if not receipt.is_persistence_ready:
-        raise PersistenceValidationError()
+        raise PersistenceValidationError(receipt)
     canonical = canonicalize_definition(definition)
     digest = compute_definition_digest(definition)
     if receipt.definition_digest != digest:
-        raise PersistenceValidationError()
+        raise PersistenceValidationError(receipt)
     return canonical, digest, receipt
 
 

--- a/tests/statblocks_v1/api/test_statblock_resource_routes.py
+++ b/tests/statblocks_v1/api/test_statblock_resource_routes.py
@@ -1,0 +1,375 @@
+"""HTTP acceptance routes for durable logical-statblock revisions (PR18)."""
+
+from __future__ import annotations
+
+import copy
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from statblocks_v1.api.dependencies import (
+    get_candidate_repository,
+    get_clock,
+    get_persistence_repository,
+    get_revision_service,
+)
+from statblocks_v1.application.revisions import SERVICE_CREATED_BY, RevisionServiceV1
+from statblocks_v1.domain.receipts import ValidationMode
+from statblocks_v1.domain.resources import GeneratedStatblockCandidateV1
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+from statblocks_v1.domain.validation import validate_definition
+from statblocks_v1.infrastructure.memory_repositories import (
+    DeterministicIdFactory,
+    InMemoryCandidateRepository,
+    InMemoryStatblockPersistenceRepository,
+)
+from statblocks_v1.testing import create_test_app
+
+
+@pytest.fixture
+def resource_client(monkeypatch, load_fixture, auth_headers):
+    monkeypatch.setenv("DUNGEONBUDDY_INTERNAL_API_KEY", auth_headers["X-DungeonBuddy-Internal-Key"])
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    candidates = InMemoryCandidateRepository(clock=lambda: now)
+    persistence = InMemoryStatblockPersistenceRepository(
+        clock=lambda: now, id_factory=DeterministicIdFactory()
+    )
+    service = RevisionServiceV1(
+        persistence=persistence, candidates=candidates, clock=lambda: now
+    )
+    app = create_test_app()
+    app.dependency_overrides[get_candidate_repository] = lambda: candidates
+    app.dependency_overrides[get_persistence_repository] = lambda: persistence
+    app.dependency_overrides[get_revision_service] = lambda: service
+    app.dependency_overrides[get_clock] = lambda: (lambda: now)
+    return TestClient(app), load_fixture("simple_bruiser"), candidates, persistence, now, auth_headers
+
+
+def _create_payload(definition: dict, key: str = "create-1", **extra) -> dict:
+    payload = {
+        "idempotency_key": key,
+        "definition": definition,
+        "change_summary": "Accepted after DungeonBuddy review.",
+        "actor": "user_123",
+        "accepted_through": {"surface": "review_panel"},
+        "asset_bindings": [{"asset_id": "asset_123", "role": "portrait"}],
+    }
+    payload.update(extra)
+    return payload
+
+
+def _store_candidate(candidates, definition: dict, now: datetime, *, candidate_id: str = "cand_000001", expired: bool = False):
+    model = StatblockDefinitionV1.model_validate(definition)
+    candidate = GeneratedStatblockCandidateV1(
+        candidate_id=candidate_id,
+        definition=model,
+        validation_receipt=validate_definition(
+            model, ValidationMode.generation_candidate, validated_at=now
+        ),
+        created_at=now,
+        expires_at=now - timedelta(seconds=1) if expired else now + timedelta(hours=1),
+    )
+    candidates.create(candidate)
+    return candidate
+
+
+def test_create_append_and_exact_replay(resource_client) -> None:
+    client, definition, _, _, _, headers = resource_client
+    created = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(definition),
+        headers=headers,
+    )
+    assert created.status_code == 200
+    first = created.json()
+    assert first["statblock"]["created_by"] == SERVICE_CREATED_BY
+    assert first["revision"]["provenance"]["accepted_by"] == "user_123"
+    assert "candidate" not in first["revision"]["provenance"]
+    statblock_id = first["statblock"]["statblock_id"]
+    first_revision_id = first["revision"]["revision_id"]
+
+    replay = client.get(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions/{first_revision_id}",
+        headers=headers,
+    )
+    assert replay.status_code == 200
+    for field in (
+        "definition",
+        "canonical_definition",
+        "definition_digest",
+        "validation_receipt",
+        "provenance",
+        "asset_bindings",
+    ):
+        assert replay.json()[field] == first["revision"][field]
+
+    appended = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(definition, "append-1"),
+            "parent_revision_id": first_revision_id,
+        },
+        headers=headers,
+    )
+    assert appended.status_code == 200
+    second = appended.json()
+    assert client.get(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions/{first_revision_id}",
+        headers=headers,
+    ).json() == first["revision"]
+
+    logical = client.get(f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}", headers=headers)
+    listed = client.get(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions", headers=headers
+    )
+    assert logical.json()["latest_revision_id"] == second["revision_id"]
+    assert [revision["revision_id"] for revision in listed.json()["revisions"]] == [
+        first_revision_id,
+        second["revision_id"],
+    ]
+
+    create_replay = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(definition),
+        headers=headers,
+    )
+    assert create_replay.status_code == 200
+    assert create_replay.json()["revision"] == first["revision"]
+
+    append_replay = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(definition, "append-1"),
+            "parent_revision_id": first_revision_id,
+        },
+        headers=headers,
+    )
+    assert append_replay.status_code == 200
+    assert append_replay.json() == second
+
+
+def test_write_idempotency_parent_stale_and_exact_locator_errors(resource_client) -> None:
+    client, definition, _, _, _, headers = resource_client
+    created = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(definition),
+        headers=headers,
+    )
+    statblock_id = created.json()["statblock"]["statblock_id"]
+    revision_id = created.json()["revision"]["revision_id"]
+
+    changed_request = _create_payload(definition)
+    changed_request["change_summary"] = "A changed acceptance decision."
+    conflict = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=changed_request,
+        headers=headers,
+    )
+    wrong_parent = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={**_create_payload(definition, "append-1"), "parent_revision_id": "rev_999999"},
+        headers=headers,
+    )
+    append = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(definition, "append-ok"),
+            "parent_revision_id": revision_id,
+        },
+        headers=headers,
+    )
+    stale_parent = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(definition, "append-stale"),
+            "parent_revision_id": revision_id,
+        },
+        headers=headers,
+    )
+    append_conflict = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(definition, "append-ok"),
+            "change_summary": "Changed append acceptance.",
+            "parent_revision_id": revision_id,
+        },
+        headers=headers,
+    )
+    wrong_pair = client.get(
+        f"/api/internal/dungeonbuddy/v1/statblocks/sb_999999/revisions/{revision_id}",
+        headers=headers,
+    )
+
+    assert conflict.status_code == 409
+    assert conflict.json()["error"]["code"] == "idempotency_conflict"
+    assert wrong_parent.status_code == 409
+    assert wrong_parent.json()["error"]["code"] == "parent_revision_mismatch"
+    assert append.status_code == 200
+    assert stale_parent.status_code == 409
+    assert stale_parent.json()["error"]["code"] == "stale_parent_revision"
+    assert append_conflict.status_code == 409
+    assert append_conflict.json()["error"]["code"] == "idempotency_conflict"
+    assert wrong_pair.status_code == 404
+
+
+def test_candidate_linked_edit_and_replay_after_ttl_deletion(resource_client) -> None:
+    client, definition, candidates, _, now, headers = resource_client
+    _store_candidate(candidates, definition, now, expired=True)
+
+    edited = copy.deepcopy(definition)
+    edited["identity"]["name"] = "Edited Bruiser"
+
+    accepted = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(edited, candidate_id="cand_000001"),
+        headers=headers,
+    )
+    assert accepted.status_code == 200
+    first = accepted.json()
+    assert first["statblock"]["created_by"] == SERVICE_CREATED_BY
+    provenance = first["revision"]["provenance"]["candidate"]
+    assert provenance["candidate_id"] == "cand_000001"
+    assert provenance["accepted_definition_changed"] is True
+
+    candidate_read = client.get(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates/cand_000001", headers=headers
+    )
+    assert candidate_read.status_code == 410
+
+    with candidates._lock:
+        del candidates._candidates["cand_000001"]
+
+    missing = client.get(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates/cand_000001", headers=headers
+    )
+    assert missing.status_code == 404
+
+    replay = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(edited, candidate_id="cand_000001"),
+        headers=headers,
+    )
+    assert replay.status_code == 200
+    assert replay.json()["revision"] == first["revision"]
+
+
+def test_open_provenance_field_rejected_and_actor_is_not_created_by(resource_client) -> None:
+    client, definition, _, _, _, headers = resource_client
+    spoofed = _create_payload(definition)
+    spoofed["provenance"] = {
+        "candidate": {
+            "candidate_id": "cand_forged",
+            "accepted_definition_changed": False,
+        }
+    }
+    response = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks", json=spoofed, headers=headers
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+    created = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(definition, actor="spoofed_owner"),
+        headers=headers,
+    )
+    assert created.status_code == 200
+    body = created.json()
+    assert body["statblock"]["created_by"] == SERVICE_CREATED_BY
+    assert body["revision"]["provenance"]["accepted_by"] == "spoofed_owner"
+
+
+def test_persistence_validation_failure_returns_receipt(resource_client, load_fixture) -> None:
+    client, _, _, _, _, headers = resource_client
+    invalid = load_fixture("unknown_resource_pool")
+    response = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(invalid),
+        headers=headers,
+    )
+    assert response.status_code == 422
+    error = response.json()["error"]
+    assert error["code"] == "validation_failed"
+    assert "validation_receipt" in error["details"]
+    assert error["details"]["is_persistence_ready"] is False
+    assert error["details"]["validation_receipt"]["mode"] == "persistence"
+    assert error["details"]["validation_receipt"]["status"] == "invalid"
+
+
+def test_concurrent_same_key_create_and_competing_appends(resource_client) -> None:
+    client, definition, _, _, _, headers = resource_client
+
+    def create_once():
+        return client.post(
+            "/api/internal/dungeonbuddy/v1/statblocks",
+            json=_create_payload(definition, "concurrent-create"),
+            headers=headers,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        create_results = list(pool.map(lambda _: create_once(), range(8)))
+    assert {result.status_code for result in create_results} == {200}
+    create_bodies = [result.json() for result in create_results]
+    assert len({body["revision"]["revision_id"] for body in create_bodies}) == 1
+    assert all(body == create_bodies[0] for body in create_bodies)
+
+    statblock_id = create_bodies[0]["statblock"]["statblock_id"]
+    parent = create_bodies[0]["revision"]["revision_id"]
+
+    def append_once(key: str):
+        return client.post(
+            f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+            json={
+                **_create_payload(definition, key),
+                "parent_revision_id": parent,
+            },
+            headers=headers,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(append_once, "append-a")
+        second = pool.submit(append_once, "append-b")
+        outcomes = [first.result(), second.result()]
+
+    statuses = sorted(result.status_code for result in outcomes)
+    assert statuses == [200, 409]
+    success = next(result for result in outcomes if result.status_code == 200)
+    conflict = next(result for result in outcomes if result.status_code == 409)
+    assert conflict.json()["error"]["code"] == "stale_parent_revision"
+    assert (
+        client.get(
+            f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}", headers=headers
+        ).json()["latest_revision_id"]
+        == success.json()["revision_id"]
+    )
+
+
+def test_openapi_resource_errors_and_no_mutation_routes(resource_client) -> None:
+    client, _, _, _, _, _ = resource_client
+    schema = client.app.openapi()
+    paths = schema["paths"]
+
+    create = paths["/api/internal/dungeonbuddy/v1/statblocks"]["post"]
+    append = paths["/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions"]["post"]
+    exact = paths[
+        "/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions/{revision_id}"
+    ]["get"]
+
+    for operation in (create, append):
+        assert "409" in operation["responses"]
+        assert "422" in operation["responses"]
+        assert "404" in operation["responses"]
+        assert "503" in operation["responses"]
+    assert "404" in exact["responses"]
+
+    revision_collection = paths["/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions"]
+    revision_item = paths[
+        "/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions/{revision_id}"
+    ]
+    assert set(revision_collection) <= {"get", "post"}
+    assert set(revision_item) == {"get"}
+    for method in ("put", "patch", "delete"):
+        assert method not in revision_collection
+        assert method not in revision_item

--- a/tests/statblocks_v1/api/test_statblock_resource_routes.py
+++ b/tests/statblocks_v1/api/test_statblock_resource_routes.py
@@ -298,6 +298,54 @@ def test_persistence_validation_failure_returns_receipt(resource_client, load_fi
     assert error["details"]["validation_receipt"]["status"] == "invalid"
 
 
+def test_idempotency_conflict_before_validation_for_changed_invalid_payload(
+    resource_client, load_fixture
+) -> None:
+    """Same key + changed invalid definition must 409, never 422 validation_failed."""
+
+    client, definition, _, _, _, headers = resource_client
+    invalid = load_fixture("unknown_resource_pool")
+
+    created = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(definition, "order-create"),
+        headers=headers,
+    )
+    assert created.status_code == 200
+    first = created.json()
+    statblock_id = first["statblock"]["statblock_id"]
+    revision_id = first["revision"]["revision_id"]
+
+    create_conflict = client.post(
+        "/api/internal/dungeonbuddy/v1/statblocks",
+        json=_create_payload(invalid, "order-create"),
+        headers=headers,
+    )
+    assert create_conflict.status_code == 409
+    assert create_conflict.json()["error"]["code"] == "idempotency_conflict"
+
+    append = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(definition, "order-append"),
+            "parent_revision_id": revision_id,
+        },
+        headers=headers,
+    )
+    assert append.status_code == 200
+
+    append_conflict = client.post(
+        f"/api/internal/dungeonbuddy/v1/statblocks/{statblock_id}/revisions",
+        json={
+            **_create_payload(invalid, "order-append"),
+            "parent_revision_id": revision_id,
+        },
+        headers=headers,
+    )
+    assert append_conflict.status_code == 409
+    assert append_conflict.json()["error"]["code"] == "idempotency_conflict"
+
+
 def test_concurrent_same_key_create_and_competing_appends(resource_client) -> None:
     client, definition, _, _, _, headers = resource_client
 

--- a/tests/statblocks_v1/integration/test_firestore_repositories.py
+++ b/tests/statblocks_v1/integration/test_firestore_repositories.py
@@ -100,6 +100,26 @@ def test_firestore_create_round_trip_and_create_replay(firestore_client, bruiser
     assert loaded.definition_digest == first.definition_digest
 
 
+def test_firestore_restart_replay_returns_identical_revision(firestore_client, bruiser):
+    """Recreate the repository instance to prove durable idempotency survives process restart."""
+    key = f"fs-restart-{uuid.uuid4().hex[:8]}"
+    first_repo = FirestoreStatblockPersistenceRepository(firestore_client)
+    command = CreateStatblockCommand(
+        caller_scope="dungeonbuddy",
+        idempotency_key=key,
+        definition=bruiser,
+        created_by="dungeonbuddy",
+        provenance={"change_summary": "restart proof"},
+    )
+    _, first = first_repo.create_statblock(command)
+
+    restarted = FirestoreStatblockPersistenceRepository(firestore_client)
+    _, replay = restarted.create_statblock(command)
+    exact = restarted.get_revision(first.statblock_id, first.revision_id)
+    assert replay.model_dump(mode="json") == first.model_dump(mode="json")
+    assert exact.model_dump(mode="json") == first.model_dump(mode="json")
+
+
 def test_firestore_candidate_ttl_timestamp_round_trip(firestore_client, bruiser):
     repository = FirestoreCandidateRepository(firestore_client)
     created = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/tests/statblocks_v1/test_health.py
+++ b/tests/statblocks_v1/test_health.py
@@ -99,6 +99,11 @@ def test_health_returns_available_capabilities(client: TestClient, auth_headers:
             "candidate_revise",
             "definition_validate",
             "candidate_read",
+            "statblock_create",
+            "statblock_revision_append",
+            "statblock_read",
+            "statblock_revision_list",
+            "statblock_revision_read",
         ],
     }
 


### PR DESCRIPTION
## Summary
- Add authenticated create/append/list/exact-read routes for logical statblocks and immutable revisions.
- Re-validate in persistence mode on accept; idempotent writes; exact revision read never falls back to latest.
- Candidate provenance retained for acceptance even when candidate GET is expired (410).

## Stack
**PR18** of PR12–PR21. Base: `feat/statblocks-v1-pr17-candidate-api` ([PR #17](https://github.com/Drakosfire/DungeonMindServer/pull/17)).
After predecessors merge, rebase onto `main` before final review.

## Test plan
- [x] `uv run pytest tests/statblocks_v1/ -q` (74 passed, 2 skipped)
- [ ] Exact-replay: create revision then GET by IDs matches digest/definition
- [ ] Confirm no revision mutation/deletion routes


Made with [Cursor](https://cursor.com)