### PR TITLE
feat(statblocks_v1): emit durable bounded diagnostics for definition_invalid

### DIFF
--- a/statblocks_v1/api/http_errors.py
+++ b/statblocks_v1/api/http_errors.py
@@ -134,7 +134,7 @@ def raise_for_generation_failure(failure: GenerationFailureV1) -> None:
         (500, "generation_failed", "Generation failed with an unexpected outcome"),
     )
     details: dict[str, object] | None = None
-    if failure.diagnostics is not None:
+    if failure.kind == "definition_invalid" and failure.diagnostics is not None:
         details = failure.diagnostics.model_dump(mode="json", exclude_none=True)
     raise StatblockV1HTTPError(
         status,

--- a/statblocks_v1/api/http_errors.py
+++ b/statblocks_v1/api/http_errors.py
@@ -133,7 +133,13 @@ def raise_for_generation_failure(failure: GenerationFailureV1) -> None:
         failure.kind,
         (500, "generation_failed", "Generation failed with an unexpected outcome"),
     )
-    raise StatblockV1HTTPError(status, GenerationTransportError(code, message))
+    details: dict[str, object] | None = None
+    if failure.diagnostics is not None:
+        details = failure.diagnostics.model_dump(mode="json", exclude_none=True)
+    raise StatblockV1HTTPError(
+        status,
+        GenerationTransportError(code, message, details=details),
+    )
 
 
 def register_error_handlers(app: FastAPI) -> None:

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -1358,6 +1358,134 @@ def _pydantic_error_message(error_type: str) -> str:
     return _SCHEMA_DIAGNOSTIC_MESSAGES.get(error_type, _GENERIC_SCHEMA_DIAGNOSTIC_MESSAGE)
 
 
+_GENERIC_DOMAIN_DIAGNOSTIC_MESSAGE = "Domain validation failed for this field."
+
+_DOMAIN_DIAGNOSTIC_MESSAGES: dict[str, str] = {
+    "DEFAULT_ARMOR_CLASS_CARDINALITY": (
+        "Exactly one armor-class profile must be marked default."
+    ),
+    "HP_METHOD_FIELDS_INCOHERENT": (
+        "Hit point method fields are incoherent for the selected method."
+    ),
+    "HP_DISPLAYED_AVERAGE_MISMATCH": (
+        "Displayed HP average does not match the typed dice formula."
+    ),
+    "RULESET_CR_INVALID": "Challenge rating is not a canonical D&D 5e CR value.",
+    "RULESET_CR_PROFICIENCY_MISMATCH": (
+        "Challenge proficiency bonus does not match the selected CR."
+    ),
+    "PASSIVE_PERCEPTION_MISMATCH": (
+        "Passive Perception must equal 10 + Perception skill value."
+    ),
+    "PASSIVE_PERCEPTION_UNVERIFIED": (
+        "Passive Perception differs from Wisdom without a typed Perception skill."
+    ),
+    "DUPLICATE_SAVING_THROW_ABILITY": (
+        "Saving throw for the same ability appears more than once."
+    ),
+    "SAVING_THROW_DERIVATION_MISMATCH": (
+        "Declared saving throw value does not match the expected derivation."
+    ),
+    "DUPLICATE_SKILL_NAME": (
+        "Skill name duplicates an earlier entry after normalization."
+    ),
+    "SKILL_DERIVATION_MISMATCH": (
+        "Declared skill value does not match the expected derivation for the "
+        "linked ability."
+    ),
+    "DUPLICATE_LOCAL_KEY": "Local key is duplicated within the indicated collection.",
+    "DEFAULT_PHASE_CARDINALITY": (
+        "A phased creature must have exactly one default phase."
+    ),
+    "UNKNOWN_ELEMENT_REFERENCE": "Referenced element key does not exist.",
+    "UNKNOWN_RESOURCE_REFERENCE": "Referenced resource key does not exist.",
+    "UNKNOWN_MULTIATTACK_ELEMENT": (
+        "Multiattack references an element key that does not exist."
+    ),
+    "FORBIDDEN_REFERENCE_CYCLE": (
+        "Multiattack reference would create a forbidden cycle."
+    ),
+    "UNKNOWN_PHASE_REFERENCE": "Referenced phase key does not exist.",
+    "UNKNOWN_MOVEMENT_REFERENCE": "Referenced movement mode key does not exist.",
+    "UNKNOWN_PHASE_ELEMENT": "Phase references an element key that does not exist.",
+    "PHASE_ELEMENT_SET_CONFLICT": (
+        "Element cannot be both enabled and disabled in the same phase."
+    ),
+    "SECTION_ACTIVATION_INCOHERENT": (
+        "Activation kind is not valid for the element section."
+    ),
+    "REACTION_TRIGGER_REQUIRED": (
+        "A reaction needs a trigger or timing expression."
+    ),
+    "LEGENDARY_RESOURCE_REQUIRED": (
+        "Legendary actions require valid resource usage and cost entries."
+    ),
+    "LEGENDARY_RESOURCE_MISMATCH": (
+        "Legendary usage resource key must match every cost resource key."
+    ),
+    "LAIR_CONTEXT_REQUIRED": "A lair action requires a lair profile.",
+    "LAIR_TIMING_REQUIRED": (
+        "A lair action requires an initiative timing expression."
+    ),
+    "RESOURCE_COST_DUPLICATE_POOL": (
+        "Resource pool appears more than once in costs; use a single cost entry."
+    ),
+    "RESOURCE_COST_EXCEEDS_POOL": "Cost exceeds the resource pool maximum.",
+    "HUMAN_ADJUDICATED_AUTOMATION_MISMATCH": (
+        "Human-adjudicated mechanics must declare manual automation support."
+    ),
+    "USAGE_FIELDS_INCOHERENT": (
+        "Usage fields are incoherent for the selected usage kind; check the "
+        "requirements for that kind at the indicated field."
+    ),
+    "ATTACK_REACH_REQUIRED": "A melee attack requires typed reach.",
+    "ATTACK_RANGE_UNEXPECTED": "A melee attack must not include typed range.",
+    "ATTACK_RANGE_REQUIRED": "A ranged attack requires typed range.",
+    "ATTACK_REACH_UNEXPECTED": "A ranged attack must not include typed reach.",
+    "ATTACK_RANGE_ORDER_INCOHERENT": (
+        "Attack long range must use the same unit and be >= normal range."
+    ),
+    "ATTACK_TARGET_RANGE_UNEXPECTED": (
+        "Attack target must not set range; use mechanic.reach or mechanic.range."
+    ),
+    "ATTACK_TARGET_COUNT_REQUIRED": "A creatures target requires count.",
+    "ATTACK_TARGET_COUNT_INCOHERENT": (
+        "Target count is incoherent for the selected target kind."
+    ),
+    "ATTACK_TARGET_AREA_REQUIRED": "An area target requires area.",
+    "ATTACK_TARGET_AREA_UNEXPECTED": "Only an area target may set area.",
+    "SPELLCASTING_MODE_INCOHERENT": (
+        "Required spellcasting fields are missing for the selected casting mode."
+    ),
+    "SPELL_GROUP_SLOTS_INCOHERENT": (
+        "Spell group slots are incoherent for the spellcasting mode and group level."
+    ),
+    "SPELL_GROUP_LEVEL_INCOHERENT": (
+        "Spell group level is missing or outside the allowed range."
+    ),
+    "SPELL_GROUP_USAGE_INCOHERENT": (
+        "Spell group usage kind is incoherent for the spellcasting mode and group "
+        "level."
+    ),
+    "RULES_TEXT_ATTACK_BONUS_MISMATCH": (
+        "Rules text attack bonus conflicts with typed attack_bonus."
+    ),
+    "RULES_TEXT_DAMAGE_MISMATCH": (
+        "Rules text damage conflicts with the first typed hit damage effect."
+    ),
+    "RULES_TEXT_SAVE_DC_MISMATCH": (
+        "Rules text save DC conflicts with typed save DC."
+    ),
+    "RULES_TEXT_SECTION_MISMATCH": (
+        "Reaction rules text unambiguously says it is used as an action."
+    ),
+}
+
+
+def _domain_diagnostic_message(code: str) -> str:
+    return _DOMAIN_DIAGNOSTIC_MESSAGES.get(code, _GENERIC_DOMAIN_DIAGNOSTIC_MESSAGE)
+
+
 _UNEXPECTED_PROVIDER_KEY_FIELD = "<unexpected_key>"
 
 
@@ -1443,17 +1571,10 @@ def _diagnostics_from_domain_receipt(
                         issue.field_path,
                         max_len=MAX_GENERATION_VALIDATION_FIELD_PATH_LEN,
                     ),
-                    message=_bound_public_text(
-                        issue.message, max_len=MAX_GENERATION_VALIDATION_MESSAGE_LEN
-                    ),
-                    suggested_resolution=(
-                        _bound_public_text(
-                            issue.suggested_resolution,
-                            max_len=MAX_GENERATION_VALIDATION_SUGGESTED_RESOLUTION_LEN,
-                        )
-                        if issue.suggested_resolution is not None
-                        else None
-                    ),
+                    message=_domain_diagnostic_message(issue.code),
+                    # Error-severity issues never carry resolutions (only warnings do,
+                    # filtered above); packets must not reflect receipt text.
+                    suggested_resolution=None,
                 )
             )
         issues = sorted(

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -1318,7 +1318,28 @@ def _pydantic_error_code(error_type: str) -> str:
     return normalized[:MAX_GENERATION_VALIDATION_CODE_LEN]
 
 
-def _field_path_from_pydantic_loc(loc: tuple[object, ...]) -> str:
+_UNEXPECTED_PROVIDER_KEY_FIELD = "<unexpected_key>"
+
+
+def _field_path_from_pydantic_loc(
+    loc: tuple[object, ...], *, error_type: str = ""
+) -> str:
+    if error_type == "extra_forbidden" and loc:
+        parent_loc = loc[:-1]
+        if not parent_loc:
+            path = _UNEXPECTED_PROVIDER_KEY_FIELD
+        else:
+            path = (
+                f"{_field_path_segments_to_public_path(parent_loc)}"
+                f".{_UNEXPECTED_PROVIDER_KEY_FIELD}"
+            )
+        return _bound_public_text(
+            path, max_len=MAX_GENERATION_VALIDATION_FIELD_PATH_LEN
+        )
+    return _field_path_segments_to_public_path(loc)
+
+
+def _field_path_segments_to_public_path(loc: tuple[object, ...]) -> str:
     if not loc:
         return "$"
     segments: list[str] = []
@@ -1340,11 +1361,15 @@ def _diagnostics_from_pydantic_validation_error(
     try:
         raw_issues: list[GenerationValidationDiagnosticIssueV1] = []
         for item in exc.errors(include_url=False, include_input=False):
+            error_type = str(item.get("type", "validation_error"))
             raw_issues.append(
                 GenerationValidationDiagnosticIssueV1(
-                    code=_pydantic_error_code(str(item.get("type", "validation_error"))),
+                    code=_pydantic_error_code(error_type),
                     severity=ValidationSeverity.error,
-                    field_path=_field_path_from_pydantic_loc(tuple(item.get("loc", ()))),
+                    field_path=_field_path_from_pydantic_loc(
+                        tuple(item.get("loc", ())),
+                        error_type=error_type,
+                    ),
                     message=_bound_public_text(
                         str(item.get("msg", "Validation failed")),
                         max_len=MAX_GENERATION_VALIDATION_MESSAGE_LEN,

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import math
 import os
+import re
 import secrets
 import time
 import unicodedata
@@ -53,6 +54,14 @@ from statblocks_v1.domain.candidate_operations import (
     CandidateGenerationFailureSnapshotV1,
     CandidateGenerationOperationV1,
     CandidateRevisionOperationV1,
+    GenerationValidationDiagnosticIssueV1,
+    GenerationValidationDiagnosticPacketV1,
+    GenerationValidationPhaseV1,
+    MAX_GENERATION_VALIDATION_CODE_LEN,
+    MAX_GENERATION_VALIDATION_DIAGNOSTIC_ISSUES,
+    MAX_GENERATION_VALIDATION_FIELD_PATH_LEN,
+    MAX_GENERATION_VALIDATION_MESSAGE_LEN,
+    MAX_GENERATION_VALIDATION_SUGGESTED_RESOLUTION_LEN,
 )
 from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import (
@@ -102,6 +111,7 @@ class DefinitionResolver(Protocol):
 class GenerationFailureV1:
     kind: str
     message: str
+    diagnostics: GenerationValidationDiagnosticPacketV1 | None = None
 
 
 @dataclass(frozen=True)
@@ -257,7 +267,7 @@ class GenerationServiceV1:
                 return loaded
             return GenerateOutcomeV1(candidate=loaded, replayed=True)
         if isinstance(began, GenerateBeginFailed):
-            return GenerationFailureV1(began.failure.kind, began.failure.message)
+            return _generation_failure_from_snapshot(began.failure)
         if isinstance(began, GenerateBeginInProgress):
             return GenerationFailureV1(
                 "generation_in_progress",
@@ -278,9 +288,7 @@ class GenerationServiceV1:
                     request_id=request_id,
                     request_digest=request_digest,
                     lease_owner=lease_owner,
-                    failure=CandidateGenerationFailureSnapshotV1(
-                        kind=result.kind, message=result.message
-                    ),
+                    failure=_failure_snapshot_from_generation_failure(result),
                 )
             except ImmutableResourceConflictError:
                 return self._resolve_after_terminal_race(
@@ -305,7 +313,7 @@ class GenerationServiceV1:
                 raise
             except GenerateOperationIntegrityError:
                 raise
-            return GenerationFailureV1(snapshot.kind, snapshot.message)
+            return _generation_failure_from_snapshot(snapshot)
 
         try:
             completed = ops.complete_generate(
@@ -455,7 +463,7 @@ class GenerationServiceV1:
                 return loaded
             return GenerateOutcomeV1(candidate=loaded, replayed=True)
         if existing.status.value == "failed" and existing.failure is not None:
-            return GenerationFailureV1(existing.failure.kind, existing.failure.message)
+            return _generation_failure_from_snapshot(existing.failure)
         if existing.status.value == "pending":
             if indeterminate:
                 return GenerationFailureV1(
@@ -565,7 +573,7 @@ class GenerationServiceV1:
                 return loaded
             return GenerateOutcomeV1(candidate=loaded, replayed=True)
         if isinstance(began, ReviseBeginFailed):
-            return GenerationFailureV1(began.failure.kind, began.failure.message)
+            return _generation_failure_from_snapshot(began.failure)
         if isinstance(began, ReviseBeginInProgress):
             return GenerationFailureV1(
                 "generation_in_progress",
@@ -587,9 +595,7 @@ class GenerationServiceV1:
                     request_id=request_id,
                     request_digest=request_digest,
                     lease_owner=lease_owner,
-                    failure=CandidateGenerationFailureSnapshotV1(
-                        kind=pinned.kind, message=pinned.message
-                    ),
+                    failure=_failure_snapshot_from_generation_failure(pinned),
                 )
             except ImmutableResourceConflictError:
                 return self._resolve_after_terminal_race_revise(
@@ -614,7 +620,7 @@ class GenerationServiceV1:
                 raise
             except ReviseOperationIntegrityError:
                 raise
-            return GenerationFailureV1(snapshot.kind, snapshot.message)
+            return _generation_failure_from_snapshot(snapshot)
         result = self._run(pinned, reserved_candidate_id=claim.candidate_id, persist=False)
         if isinstance(result, GenerationFailureV1):
             try:
@@ -623,9 +629,7 @@ class GenerationServiceV1:
                     request_id=request_id,
                     request_digest=request_digest,
                     lease_owner=lease_owner,
-                    failure=CandidateGenerationFailureSnapshotV1(
-                        kind=result.kind, message=result.message
-                    ),
+                    failure=_failure_snapshot_from_generation_failure(result),
                 )
             except ImmutableResourceConflictError:
                 return self._resolve_after_terminal_race_revise(
@@ -650,7 +654,7 @@ class GenerationServiceV1:
                 raise
             except ReviseOperationIntegrityError:
                 raise
-            return GenerationFailureV1(snapshot.kind, snapshot.message)
+            return _generation_failure_from_snapshot(snapshot)
 
         try:
             completed = ops.complete_revise(
@@ -800,7 +804,7 @@ class GenerationServiceV1:
                 return loaded
             return GenerateOutcomeV1(candidate=loaded, replayed=True)
         if existing.status.value == "failed" and existing.failure is not None:
-            return GenerationFailureV1(existing.failure.kind, existing.failure.message)
+            return _generation_failure_from_snapshot(existing.failure)
         if existing.status.value == "pending":
             if indeterminate:
                 return GenerationFailureV1(
@@ -910,9 +914,12 @@ class GenerationServiceV1:
             )
         try:
             definition = StatblockDefinitionV1.model_validate(outcome.payload)
-        except ValidationError:
+        except ValidationError as exc:
+            diagnostics = _diagnostics_from_pydantic_validation_error(exc)
             return GenerationFailureV1(
-                "definition_invalid", "Provider output does not match StatblockDefinitionV1"
+                "definition_invalid",
+                "Provider output does not match StatblockDefinitionV1",
+                diagnostics=diagnostics,
             )
         if not _ruleset_matches(definition.ruleset, intent.ruleset):
             return GenerationFailureV1(
@@ -925,8 +932,11 @@ class GenerationServiceV1:
             definition, ValidationMode.generation_candidate, validated_at=now
         )
         if receipt.status is ValidationStatus.invalid:
+            diagnostics = _diagnostics_from_domain_receipt(receipt)
             return GenerationFailureV1(
-                "definition_invalid", "Provider output has structural or reference errors"
+                "definition_invalid",
+                "Provider output has structural or reference errors",
+                diagnostics=diagnostics,
             )
         if intent.source_definition is not None and intent.preserve_element_keys:
             receipt = _with_key_preservation_warnings(
@@ -1287,6 +1297,133 @@ def _with_key_preservation_warnings(
             "status": status,
             "validator_version": f"{receipt.validator_version}+{KEY_PRESERVATION_PASS_VERSION}",
         }
+    )
+
+
+def _bound_public_text(value: str, *, max_len: int) -> str:
+    normalized = unicodedata.normalize("NFC", value).strip()
+    if not normalized:
+        return "Validation failed"
+    if len(normalized) <= max_len:
+        return normalized
+    return normalized[: max_len - 1] + "…"
+
+
+def _pydantic_error_code(error_type: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_]+", "_", error_type).strip("_").upper()
+    if not normalized:
+        normalized = "PYDANTIC_VALIDATION"
+    if not re.match(r"^[A-Z][A-Z0-9_]*$", normalized):
+        normalized = f"PYDANTIC_{normalized}"[:MAX_GENERATION_VALIDATION_CODE_LEN]
+    return normalized[:MAX_GENERATION_VALIDATION_CODE_LEN]
+
+
+def _field_path_from_pydantic_loc(loc: tuple[object, ...]) -> str:
+    if not loc:
+        return "$"
+    segments: list[str] = []
+    for part in loc:
+        if isinstance(part, int):
+            if not segments:
+                segments.append(f"[{part}]")
+            else:
+                segments[-1] = f"{segments[-1]}[{part}]"
+        else:
+            segments.append(str(part))
+    path = ".".join(segments)
+    return _bound_public_text(path, max_len=MAX_GENERATION_VALIDATION_FIELD_PATH_LEN)
+
+
+def _diagnostics_from_pydantic_validation_error(
+    exc: ValidationError,
+) -> GenerationValidationDiagnosticPacketV1 | None:
+    try:
+        raw_issues: list[GenerationValidationDiagnosticIssueV1] = []
+        for item in exc.errors(include_url=False, include_input=False):
+            raw_issues.append(
+                GenerationValidationDiagnosticIssueV1(
+                    code=_pydantic_error_code(str(item.get("type", "validation_error"))),
+                    severity=ValidationSeverity.error,
+                    field_path=_field_path_from_pydantic_loc(tuple(item.get("loc", ()))),
+                    message=_bound_public_text(
+                        str(item.get("msg", "Validation failed")),
+                        max_len=MAX_GENERATION_VALIDATION_MESSAGE_LEN,
+                    ),
+                    suggested_resolution=None,
+                )
+            )
+        issues = sorted(
+            raw_issues,
+            key=lambda issue: (issue.field_path, issue.code, issue.message),
+        )[:MAX_GENERATION_VALIDATION_DIAGNOSTIC_ISSUES]
+        return GenerationValidationDiagnosticPacketV1(
+            phase=GenerationValidationPhaseV1.schema_validation,
+            issue_count=len(issues),
+            issues=issues,
+        )
+    except Exception:
+        return None
+
+
+def _diagnostics_from_domain_receipt(
+    receipt: ValidationReceiptV1,
+) -> GenerationValidationDiagnosticPacketV1 | None:
+    try:
+        raw_issues: list[GenerationValidationDiagnosticIssueV1] = []
+        for issue in receipt.issues:
+            if issue.severity is not ValidationSeverity.error:
+                continue
+            raw_issues.append(
+                GenerationValidationDiagnosticIssueV1(
+                    code=issue.code[:MAX_GENERATION_VALIDATION_CODE_LEN],
+                    severity=issue.severity,
+                    field_path=_bound_public_text(
+                        issue.field_path,
+                        max_len=MAX_GENERATION_VALIDATION_FIELD_PATH_LEN,
+                    ),
+                    message=_bound_public_text(
+                        issue.message, max_len=MAX_GENERATION_VALIDATION_MESSAGE_LEN
+                    ),
+                    suggested_resolution=(
+                        _bound_public_text(
+                            issue.suggested_resolution,
+                            max_len=MAX_GENERATION_VALIDATION_SUGGESTED_RESOLUTION_LEN,
+                        )
+                        if issue.suggested_resolution is not None
+                        else None
+                    ),
+                )
+            )
+        issues = sorted(
+            raw_issues,
+            key=lambda item: (item.field_path, item.code, item.message),
+        )[:MAX_GENERATION_VALIDATION_DIAGNOSTIC_ISSUES]
+        return GenerationValidationDiagnosticPacketV1(
+            phase=GenerationValidationPhaseV1.domain_validation,
+            issue_count=len(issues),
+            issues=issues,
+        )
+    except Exception:
+        return None
+
+
+def _failure_snapshot_from_generation_failure(
+    failure: GenerationFailureV1,
+) -> CandidateGenerationFailureSnapshotV1:
+    return CandidateGenerationFailureSnapshotV1(
+        kind=failure.kind,
+        message=failure.message,
+        diagnostics=failure.diagnostics,
+    )
+
+
+def _generation_failure_from_snapshot(
+    snapshot: CandidateGenerationFailureSnapshotV1,
+) -> GenerationFailureV1:
+    return GenerationFailureV1(
+        snapshot.kind,
+        snapshot.message,
+        diagnostics=snapshot.diagnostics,
     )
 
 

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -1318,6 +1318,46 @@ def _pydantic_error_code(error_type: str) -> str:
     return normalized[:MAX_GENERATION_VALIDATION_CODE_LEN]
 
 
+_GENERIC_SCHEMA_DIAGNOSTIC_MESSAGE = "Validation failed for this field."
+
+_SCHEMA_DIAGNOSTIC_MESSAGES: dict[str, str] = {
+    "missing": "Required field is missing.",
+    "extra_forbidden": "Unexpected field is not permitted.",
+    "union_tag_invalid": (
+        "Unrecognized element kind; the value does not match any supported kind "
+        "for this field."
+    ),
+    "union_tag_not_found": (
+        "Missing the discriminator field required to determine the element type."
+    ),
+    "literal_error": "Value must equal the required constant for this field.",
+    "enum": "Value must be one of the allowed options.",
+    "string_type": "Value must be a string.",
+    "string_too_short": "String value is too short.",
+    "string_too_long": "String value is too long.",
+    "string_pattern_mismatch": "String value does not match the required pattern.",
+    "int_type": "Value must be an integer.",
+    "int_parsing": "Value must be a valid integer.",
+    "float_type": "Value must be a number.",
+    "float_parsing": "Value must be a valid number.",
+    "greater_than": "Value must be greater than the allowed minimum.",
+    "greater_than_equal": "Value must be greater than or equal to the allowed minimum.",
+    "less_than": "Value must be less than the allowed maximum.",
+    "less_than_equal": "Value must be less than or equal to the allowed maximum.",
+    "list_type": "Value must be a list.",
+    "too_short": "List has too few items.",
+    "too_long": "List has too many items.",
+    "dict_type": "Value must be an object.",
+    "model_type": "Value must be a structured object with the expected fields.",
+    "bool_type": "Value must be true or false.",
+    "value_error": "Value is not valid for this field.",
+}
+
+
+def _pydantic_error_message(error_type: str) -> str:
+    return _SCHEMA_DIAGNOSTIC_MESSAGES.get(error_type, _GENERIC_SCHEMA_DIAGNOSTIC_MESSAGE)
+
+
 _UNEXPECTED_PROVIDER_KEY_FIELD = "<unexpected_key>"
 
 
@@ -1370,10 +1410,7 @@ def _diagnostics_from_pydantic_validation_error(
                         tuple(item.get("loc", ())),
                         error_type=error_type,
                     ),
-                    message=_bound_public_text(
-                        str(item.get("msg", "Validation failed")),
-                        max_len=MAX_GENERATION_VALIDATION_MESSAGE_LEN,
-                    ),
+                    message=_pydantic_error_message(error_type),
                     suggested_resolution=None,
                 )
             )

--- a/statblocks_v1/domain/candidate_operations.py
+++ b/statblocks_v1/domain/candidate_operations.py
@@ -86,6 +86,14 @@ class CandidateGenerationFailureSnapshotV1(StrictModel):
     message: str = Field(min_length=1)
     diagnostics: GenerationValidationDiagnosticPacketV1 | None = None
 
+    @model_validator(mode="after")
+    def diagnostics_only_for_definition_invalid(self) -> Self:
+        if self.diagnostics is not None and self.kind != "definition_invalid":
+            raise ValueError(
+                "diagnostics are only permitted for definition_invalid failures"
+            )
+        return self
+
 
 class CandidateGenerationOperationV1(StrictModel):
     """Lease-bearing generate operation bound to one reserved candidate_id."""

--- a/statblocks_v1/domain/candidate_operations.py
+++ b/statblocks_v1/domain/candidate_operations.py
@@ -9,9 +9,65 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from statblocks_v1.domain.primitives import StrictModel
+from statblocks_v1.domain.receipts import ValidationSeverity
+
+GENERATION_VALIDATION_DIAGNOSTICS_VERSION: Literal[
+    "generation-validation-diagnostics-v1"
+] = "generation-validation-diagnostics-v1"
+
+MAX_GENERATION_VALIDATION_DIAGNOSTIC_ISSUES = 32
+MAX_GENERATION_VALIDATION_FIELD_PATH_LEN = 256
+MAX_GENERATION_VALIDATION_CODE_LEN = 64
+MAX_GENERATION_VALIDATION_MESSAGE_LEN = 512
+MAX_GENERATION_VALIDATION_SUGGESTED_RESOLUTION_LEN = 512
+
+
+class GenerationValidationPhaseV1(str, Enum):
+    schema_validation = "schema_validation"
+    domain_validation = "domain_validation"
+
+
+class GenerationValidationDiagnosticIssueV1(StrictModel):
+    """Bounded public issue for generation validation failures."""
+
+    code: str = Field(min_length=1, max_length=MAX_GENERATION_VALIDATION_CODE_LEN)
+    severity: ValidationSeverity
+    field_path: str = Field(
+        min_length=1, max_length=MAX_GENERATION_VALIDATION_FIELD_PATH_LEN
+    )
+    message: str = Field(min_length=1, max_length=MAX_GENERATION_VALIDATION_MESSAGE_LEN)
+    suggested_resolution: str | None = Field(
+        default=None, max_length=MAX_GENERATION_VALIDATION_SUGGESTED_RESOLUTION_LEN
+    )
+
+
+class GenerationValidationDiagnosticPacketV1(StrictModel):
+    """Safe diagnostic packet persisted on terminal definition_invalid failures."""
+
+    schema_version: Literal["generation-validation-diagnostics-v1"] = (
+        GENERATION_VALIDATION_DIAGNOSTICS_VERSION
+    )
+    phase: GenerationValidationPhaseV1
+    issue_count: int = Field(ge=0)
+    issues: list[GenerationValidationDiagnosticIssueV1] = Field(default_factory=list)
+
+    @field_validator("issues")
+    @classmethod
+    def _bounded_issue_list(
+        cls, issues: list[GenerationValidationDiagnosticIssueV1]
+    ) -> list[GenerationValidationDiagnosticIssueV1]:
+        if len(issues) > MAX_GENERATION_VALIDATION_DIAGNOSTIC_ISSUES:
+            return issues[:MAX_GENERATION_VALIDATION_DIAGNOSTIC_ISSUES]
+        return issues
+
+    @model_validator(mode="after")
+    def issue_count_matches_issues(self) -> Self:
+        if self.issue_count != len(self.issues):
+            raise ValueError("issue_count must equal len(issues)")
+        return self
 
 GENERATE_CANDIDATE_OPERATION: Literal["generate_candidate"] = "generate_candidate"
 REVISE_CANDIDATE_OPERATION: Literal["revise_candidate"] = "revise_candidate"
@@ -28,6 +84,7 @@ class CandidateGenerationFailureSnapshotV1(StrictModel):
 
     kind: str = Field(min_length=1)
     message: str = Field(min_length=1)
+    diagnostics: GenerationValidationDiagnosticPacketV1 | None = None
 
 
 class CandidateGenerationOperationV1(StrictModel):

--- a/tests/statblocks_v1/api/test_candidate_routes.py
+++ b/tests/statblocks_v1/api/test_candidate_routes.py
@@ -520,6 +520,38 @@ def test_extra_forbidden_provider_key_sentinel_absent_from_generate_http_and_rep
     assert len(provider.calls) == 1
 
 
+RAW_PROVIDER_VALUE_SENTINEL = "__RAW_PROVIDER_VALUE_SENTINEL__"
+
+
+def test_union_tag_invalid_provider_value_sentinel_absent_from_generate_http_and_replay(
+    api_client, load_fixture
+) -> None:
+    client, provider, headers, *_ = api_client
+    outcome_payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    outcome_payload["rule_elements"][0]["mechanic"]["kind"] = RAW_PROVIDER_VALUE_SENTINEL
+    provider._outcome = ProviderOutcomeV1.succeeded(outcome_payload)
+    payload = _generate_payload("raw-value-http")
+    first = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=payload,
+        headers=headers,
+    )
+    second = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=payload,
+        headers=headers,
+    )
+    assert first.status_code == 422
+    assert second.status_code == 422
+    assert RAW_PROVIDER_VALUE_SENTINEL not in first.text
+    assert RAW_PROVIDER_VALUE_SENTINEL not in second.text
+    assert len(provider.calls) == 1
+    issues = first.json()["error"]["details"]["issues"]
+    union_issues = [issue for issue in issues if issue["code"] == "UNION_TAG_INVALID"]
+    assert union_issues
+    assert RAW_PROVIDER_VALUE_SENTINEL not in union_issues[0]["message"]
+
+
 def test_misbound_generation_failure_never_exposes_diagnostics_in_http(api_client) -> None:
     from statblocks_v1.domain.candidate_operations import (
         GenerationValidationDiagnosticIssueV1,

--- a/tests/statblocks_v1/api/test_candidate_routes.py
+++ b/tests/statblocks_v1/api/test_candidate_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from datetime import datetime, timezone
 
 import pytest
@@ -14,7 +15,7 @@ from statblocks_v1.api.dependencies import (
 )
 from statblocks_v1.api.http_errors import register_error_handlers
 from statblocks_v1.api.router import router as v1_router
-from statblocks_v1.application.generation import GenerationServiceV1
+from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1
 from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
 from statblocks_v1.application.repositories import CreateStatblockCommand
 from statblocks_v1.application.resolvers import PersistenceDefinitionResolver
@@ -474,6 +475,89 @@ def test_definition_invalid_generate_and_revise_emit_matching_diagnostic_envelop
     assert rev_body["code"] == "validation_failed"
     assert rev_body["details"]["phase"] == "domain_validation"
     assert len(invalid_provider.calls) == 2
+
+
+RAW_PROVIDER_KEY_SENTINEL = "__RAW_PROVIDER_KEY_SENTINEL__"
+
+
+def _payload_with_raw_extra_provider_keys(load_fixture) -> dict:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    payload[RAW_PROVIDER_KEY_SENTINEL] = "x"
+    payload["rule_elements"][0][RAW_PROVIDER_KEY_SENTINEL] = "y"
+    return payload
+
+
+def test_extra_forbidden_provider_key_sentinel_absent_from_generate_http_and_replay(
+    api_client, load_fixture
+) -> None:
+    client, provider, headers, *_ = api_client
+    provider._outcome = ProviderOutcomeV1.succeeded(
+        _payload_with_raw_extra_provider_keys(load_fixture)
+    )
+    payload = _generate_payload("raw-key-http")
+    first = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=payload,
+        headers=headers,
+    )
+    second = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=payload,
+        headers=headers,
+    )
+    assert first.status_code == 422
+    assert second.status_code == 422
+    assert RAW_PROVIDER_KEY_SENTINEL not in first.text
+    assert RAW_PROVIDER_KEY_SENTINEL not in second.text
+    details = first.json()["error"]["details"]
+    extra_paths = {
+        issue["field_path"]
+        for issue in details["issues"]
+        if issue["code"] == "EXTRA_FORBIDDEN"
+    }
+    assert "<unexpected_key>" in extra_paths
+    assert "rule_elements[0].<unexpected_key>" in extra_paths
+    assert len(provider.calls) == 1
+
+
+def test_misbound_generation_failure_never_exposes_diagnostics_in_http(api_client) -> None:
+    from statblocks_v1.domain.candidate_operations import (
+        GenerationValidationDiagnosticIssueV1,
+        GenerationValidationDiagnosticPacketV1,
+        GenerationValidationPhaseV1,
+    )
+    from statblocks_v1.domain.receipts import ValidationSeverity
+
+    client, _, headers, *_ = api_client
+    packet = GenerationValidationDiagnosticPacketV1(
+        phase=GenerationValidationPhaseV1.schema_validation,
+        issue_count=1,
+        issues=[
+            GenerationValidationDiagnosticIssueV1(
+                code="MISSING",
+                severity=ValidationSeverity.error,
+                field_path="identity.name",
+                message="Field required",
+            )
+        ],
+    )
+
+    class MisboundFailureService:
+        def generate(self, command):
+            return GenerationFailureV1(
+                "unexpected_kind_for_test", "boom", diagnostics=packet
+            )
+
+    client.app.dependency_overrides[get_generation_service] = lambda: MisboundFailureService()
+    response = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=_generate_payload("misbound-diagnostics"),
+        headers=headers,
+    )
+    assert response.status_code == 500
+    error = response.json()["error"]
+    assert error["code"] == "generation_failed"
+    assert "details" not in error
 
 
 def test_ruleset_and_source_digest_mismatches_are_not_provider_unavailable(

--- a/tests/statblocks_v1/api/test_candidate_routes.py
+++ b/tests/statblocks_v1/api/test_candidate_routes.py
@@ -419,6 +419,61 @@ def test_generation_failures_use_typed_envelopes(api_client, outcome, status, co
 
     assert response.status_code == status
     assert response.json()["error"]["code"] == code
+    if code == "validation_failed":
+        details = response.json()["error"].get("details")
+        assert details is not None
+        assert details.get("phase") == "schema_validation"
+        assert details.get("issue_count", 0) >= 1
+        assert "issues" in details
+        assert "__DMS_VAL01_RAW_PAYLOAD_SENTINEL__" not in response.text
+        assert '"input":' not in response.text
+
+
+def test_definition_invalid_generate_and_revise_emit_matching_diagnostic_envelopes(
+    api_client, load_fixture
+) -> None:
+    client, _, headers, *_ = api_client
+    candidates = InMemoryCandidateRepository()
+    invalid_provider = FakeDefinitionProvider(load_fixture("dangling_multiattack_ref"))
+    client.app.dependency_overrides[get_generation_service] = lambda: GenerationServiceV1(
+        provider=invalid_provider,
+        candidates=candidates,
+        settings=GenerationSettingsV1("test-model", 1, 0, 60),
+        candidate_id_factory=lambda: "cand_diag",
+        generate_operations=InMemoryCandidateGenerationOperationRepository(candidates),
+        revise_operations=InMemoryCandidateRevisionOperationRepository(candidates),
+    )
+
+    generate = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=_generate_payload("diag-generate"),
+        headers=headers,
+    )
+    assert generate.status_code == 422
+    gen_body = generate.json()["error"]
+    assert gen_body["code"] == "validation_failed"
+    assert gen_body["message"] == "Generated definition failed validation"
+    assert gen_body["details"]["phase"] == "domain_validation"
+
+    revise_payload = {
+        "request_id": "diag-revise",
+        "ruleset": {"system": "dnd5e", "edition": "2024", "house_ruleset_id": None},
+        "revision_instructions": ["Tweak the latchling."],
+        "source_definition": load_fixture("dangling_multiattack_ref"),
+        "intent": {},
+        "context": {},
+        "preserve_element_keys": True,
+    }
+    revise = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:revise",
+        json=revise_payload,
+        headers=headers,
+    )
+    assert revise.status_code == 422
+    rev_body = revise.json()["error"]
+    assert rev_body["code"] == "validation_failed"
+    assert rev_body["details"]["phase"] == "domain_validation"
+    assert len(invalid_provider.calls) == 2
 
 
 def test_ruleset_and_source_digest_mismatches_are_not_provider_unavailable(

--- a/tests/statblocks_v1/api/test_candidate_routes.py
+++ b/tests/statblocks_v1/api/test_candidate_routes.py
@@ -15,7 +15,11 @@ from statblocks_v1.api.dependencies import (
 )
 from statblocks_v1.api.http_errors import register_error_handlers
 from statblocks_v1.api.router import router as v1_router
-from statblocks_v1.application.generation import GenerationFailureV1, GenerationServiceV1
+from statblocks_v1.application.generation import (
+    GenerationFailureV1,
+    GenerationServiceV1,
+    _DOMAIN_DIAGNOSTIC_MESSAGES,
+)
 from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
 from statblocks_v1.application.repositories import CreateStatblockCommand
 from statblocks_v1.application.resolvers import PersistenceDefinitionResolver
@@ -521,6 +525,45 @@ def test_extra_forbidden_provider_key_sentinel_absent_from_generate_http_and_rep
 
 
 RAW_PROVIDER_VALUE_SENTINEL = "__RAW_PROVIDER_VALUE_SENTINEL__"
+RAW_DOMAIN_VALUE_SENTINEL = "__RAW_DOMAIN_VALUE_SENTINEL__"
+
+
+def test_domain_provider_value_sentinel_absent_from_generate_http_and_replay(
+    api_client, load_fixture
+) -> None:
+    client, provider, headers, *_ = api_client
+    outcome_payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    sentinel_skill = {
+        "skill": RAW_DOMAIN_VALUE_SENTINEL,
+        "ability": "strength",
+        "value": 6,
+        "derivation": "standard",
+    }
+    outcome_payload["proficiencies"]["skills"] = [
+        sentinel_skill,
+        copy.deepcopy(sentinel_skill),
+    ]
+    provider._outcome = ProviderOutcomeV1.succeeded(outcome_payload)
+    payload = _generate_payload("raw-domain-value-http")
+    first = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=payload,
+        headers=headers,
+    )
+    second = client.post(
+        "/api/internal/dungeonbuddy/v1/statblock-candidates:generate",
+        json=payload,
+        headers=headers,
+    )
+    assert first.status_code == 422
+    assert second.status_code == 422
+    assert RAW_DOMAIN_VALUE_SENTINEL not in first.text
+    assert RAW_DOMAIN_VALUE_SENTINEL not in second.text
+    assert len(provider.calls) == 1
+    issues = first.json()["error"]["details"]["issues"]
+    dup_issues = [issue for issue in issues if issue["code"] == "DUPLICATE_SKILL_NAME"]
+    assert dup_issues
+    assert dup_issues[0]["message"] == _DOMAIN_DIAGNOSTIC_MESSAGES["DUPLICATE_SKILL_NAME"]
 
 
 def test_union_tag_invalid_provider_value_sentinel_absent_from_generate_http_and_replay(

--- a/tests/statblocks_v1/integration/test_firestore_repositories.py
+++ b/tests/statblocks_v1/integration/test_firestore_repositories.py
@@ -432,6 +432,87 @@ def test_firestore_generate_ops_atomic_complete_and_replay(firestore_client, bru
     assert all(item.already_completed for item in results)
 
 
+def test_firestore_generate_failure_diagnostics_round_trip(firestore_client):
+    from statblocks_v1.application.commands import (
+        CallerProvenanceV1,
+        GenerateStatblockCommandV1,
+        SourceSnapshotV1,
+    )
+    from statblocks_v1.application.repositories import (
+        GenerateBeginFailed,
+        compute_generate_candidate_digest,
+    )
+    from statblocks_v1.domain.candidate_operations import (
+        CandidateGenerationFailureSnapshotV1,
+        GenerationValidationDiagnosticIssueV1,
+        GenerationValidationDiagnosticPacketV1,
+        GenerationValidationPhaseV1,
+    )
+    from statblocks_v1.domain.profiles import RulesetRef
+    from statblocks_v1.domain.receipts import ValidationSeverity
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    suffix = uuid.uuid4().hex[:8]
+    ops = FirestoreCandidateGenerationOperationRepository(
+        firestore_client,
+        clock=lambda: now,
+        generate_ops_collection=GENERATE_OPS_COLLECTION,
+    )
+    command = GenerateStatblockCommandV1(
+        request_id=f"fs-fail-{suffix}",
+        ruleset=RulesetRef(system="dnd5e", edition="2024"),
+        source=SourceSnapshotV1(name_hint="X", description="Y"),
+        caller=CallerProvenanceV1(caller_scope="dungeonbuddy"),
+    )
+    digest = compute_generate_candidate_digest(command)
+    ops.begin_generate(
+        caller_scope="dungeonbuddy",
+        request_id=command.request_id,
+        request_digest=digest,
+        candidate_id_factory=lambda: f"cand_fail{suffix}",
+        lease_owner="owner-a",
+        lease_duration_seconds=120,
+    )
+    packet = GenerationValidationDiagnosticPacketV1(
+        phase=GenerationValidationPhaseV1.domain_validation,
+        issue_count=1,
+        issues=[
+            GenerationValidationDiagnosticIssueV1(
+                code="UNKNOWN_RESOURCE_REFERENCE",
+                severity=ValidationSeverity.error,
+                field_path="rule_elements[0].costs[0].resource_key",
+                message="Unknown local reference 'missing_pool'.",
+            )
+        ],
+    )
+    stored = ops.fail_generate(
+        caller_scope="dungeonbuddy",
+        request_id=command.request_id,
+        request_digest=digest,
+        lease_owner="owner-a",
+        failure=CandidateGenerationFailureSnapshotV1(
+            kind="definition_invalid",
+            message="Generated definition failed validation",
+            diagnostics=packet,
+        ),
+    )
+    assert stored.diagnostics is not None
+    assert stored.diagnostics.model_dump(mode="json") == packet.model_dump(mode="json")
+
+    ops2 = FirestoreCandidateGenerationOperationRepository(firestore_client, clock=lambda: now)
+    replay = ops2.begin_generate(
+        caller_scope="dungeonbuddy",
+        request_id=command.request_id,
+        request_digest=digest,
+        candidate_id_factory=lambda: f"cand_fail2{suffix}",
+        lease_owner="owner-b",
+        lease_duration_seconds=120,
+    )
+    assert isinstance(replay, GenerateBeginFailed)
+    assert replay.failure.diagnostics is not None
+    assert replay.failure.diagnostics.model_dump(mode="json") == packet.model_dump(mode="json")
+
+
 def test_firestore_revise_ops_atomic_complete_and_replay(firestore_client, bruiser):
     from statblocks_v1.application.commands import (
         CallerProvenanceV1,

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import copy
 import math
+import re
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -22,7 +24,10 @@ from statblocks_v1.application.generation import (
     GenerateOutcomeV1,
     GenerationFailureV1,
     GenerationServiceV1,
+    _DOMAIN_DIAGNOSTIC_MESSAGES,
+    _GENERIC_DOMAIN_DIAGNOSTIC_MESSAGE,
     _SCHEMA_DIAGNOSTIC_MESSAGES,
+    _diagnostics_from_domain_receipt,
     _digest_text,
 )
 from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
@@ -32,7 +37,7 @@ from statblocks_v1.application.settings import GenerationSettingsV1
 from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.errors import InternalServiceMisconfiguredError, RevisionNotFoundError
 from statblocks_v1.domain.profiles import RulesetEdition, RulesetRef
-from statblocks_v1.domain.receipts import ValidationStatus
+from statblocks_v1.domain.receipts import ValidationSeverity, ValidationStatus
 from statblocks_v1.domain.resources import AssetWarningCode, ExactRevisionLocatorV1
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 from statblocks_v1.infrastructure.fake_provider import FakeDefinitionProvider
@@ -2455,6 +2460,87 @@ def test_union_tag_not_found_uses_template_message(load_fixture) -> None:
     ]
     assert not_found_issues
     assert not_found_issues[0].message == _SCHEMA_DIAGNOSTIC_MESSAGES["union_tag_not_found"]
+
+
+RAW_DOMAIN_VALUE_SENTINEL = "__RAW_DOMAIN_VALUE_SENTINEL__"
+
+
+def test_domain_duplicate_skill_provider_value_sentinel_absent_from_diagnostics_and_persistence(
+    load_fixture,
+) -> None:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    sentinel_skill = {
+        "skill": RAW_DOMAIN_VALUE_SENTINEL,
+        "ability": "strength",
+        "value": 6,
+        "derivation": "standard",
+    }
+    payload["proficiencies"]["skills"] = [sentinel_skill, copy.deepcopy(sentinel_skill)]
+    provider = FakeDefinitionProvider(ProviderOutcomeV1.succeeded(payload))
+    service = _service(None, provider=provider)
+    result = service.generate(_command(request_id="req_domain_duplicate_skill"))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "definition_invalid"
+    assert result.diagnostics is not None
+    assert result.diagnostics.phase.value == "domain_validation"
+    dup_issues = [
+        issue for issue in result.diagnostics.issues if issue.code == "DUPLICATE_SKILL_NAME"
+    ]
+    assert dup_issues
+    assert dup_issues[0].message == _DOMAIN_DIAGNOSTIC_MESSAGES["DUPLICATE_SKILL_NAME"]
+    diag_json = result.diagnostics.model_dump_json()
+    assert RAW_DOMAIN_VALUE_SENTINEL not in diag_json
+
+    ops = service._generate_operations
+    assert ops is not None
+    operation = ops.get_generate_operation("tests", "req_domain_duplicate_skill")
+    assert operation is not None
+    assert RAW_DOMAIN_VALUE_SENTINEL not in operation.model_dump_json()
+
+
+def test_unknown_domain_code_uses_generic_message() -> None:
+    from statblocks_v1.domain.canonicalization import CANONICALIZER_VERSION
+    from statblocks_v1.domain.receipts import (
+        VALIDATOR_VERSION,
+        ValidationIssueV1,
+        ValidationMode,
+        ValidationReceiptV1,
+    )
+
+    receipt = ValidationReceiptV1(
+        status=ValidationStatus.invalid,
+        mode=ValidationMode.generation_candidate,
+        validator_version=VALIDATOR_VERSION,
+        canonicalizer_version=CANONICALIZER_VERSION,
+        definition_digest="sha256:" + "0" * 64,
+        validated_at=datetime.now(timezone.utc),
+        issues=[
+            ValidationIssueV1(
+                code="FUTURE_CODE_NOT_YET_TEMPLATED",
+                severity=ValidationSeverity.error,
+                field_path="identity.name",
+                message="Provider-authored receipt text must not leak.",
+                suggested_resolution="Also must not leak.",
+            )
+        ],
+    )
+    packet = _diagnostics_from_domain_receipt(receipt)
+    assert packet is not None
+    assert len(packet.issues) == 1
+    assert packet.issues[0].message == _GENERIC_DOMAIN_DIAGNOSTIC_MESSAGE
+    assert packet.issues[0].suggested_resolution is None
+
+
+def test_domain_diagnostic_templates_cover_all_validator_codes() -> None:
+    import statblocks_v1.domain.validation as validation_module
+
+    source = Path(validation_module.__file__).read_text()
+    codes = set(
+        re.findall(r'^\s+"([A-Z][A-Z0-9_]{3,})",?$', source, re.MULTILINE)
+    )
+    assert len(codes) == 49
+    assert codes == set(_DOMAIN_DIAGNOSTIC_MESSAGES.keys())
 
 
 def test_candidate_generation_failure_snapshot_diagnostics_invariant() -> None:

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -22,6 +22,7 @@ from statblocks_v1.application.generation import (
     GenerateOutcomeV1,
     GenerationFailureV1,
     GenerationServiceV1,
+    _SCHEMA_DIAGNOSTIC_MESSAGES,
     _digest_text,
 )
 from statblocks_v1.application.provider import ProviderOutcomeKind, ProviderOutcomeV1
@@ -2404,6 +2405,56 @@ def test_extra_forbidden_provider_key_sentinel_sanitized_at_service_and_persiste
     assert operation is not None
     op_json = operation.model_dump_json()
     assert RAW_PROVIDER_KEY_SENTINEL not in op_json
+
+
+RAW_PROVIDER_VALUE_SENTINEL = "__RAW_PROVIDER_VALUE_SENTINEL__"
+
+
+def test_union_tag_invalid_provider_value_sentinel_absent_from_diagnostics_and_persistence(
+    load_fixture,
+) -> None:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    payload["rule_elements"][0]["mechanic"]["kind"] = RAW_PROVIDER_VALUE_SENTINEL
+    provider = FakeDefinitionProvider(ProviderOutcomeV1.succeeded(payload))
+    service = _service(None, provider=provider)
+    result = service.generate(_command(request_id="req_union_tag_invalid"))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.diagnostics is not None
+    assert result.diagnostics.phase.value == "schema_validation"
+    diag_json = result.diagnostics.model_dump_json()
+    assert RAW_PROVIDER_VALUE_SENTINEL not in diag_json
+    union_issues = [
+        issue
+        for issue in result.diagnostics.issues
+        if issue.code == "UNION_TAG_INVALID"
+    ]
+    assert union_issues
+    assert union_issues[0].message == _SCHEMA_DIAGNOSTIC_MESSAGES["union_tag_invalid"]
+
+    ops = service._generate_operations
+    assert ops is not None
+    operation = ops.get_generate_operation("tests", "req_union_tag_invalid")
+    assert operation is not None
+    assert RAW_PROVIDER_VALUE_SENTINEL not in operation.model_dump_json()
+
+
+def test_union_tag_not_found_uses_template_message(load_fixture) -> None:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    payload["rule_elements"][0]["mechanic"].pop("kind", None)
+    provider = FakeDefinitionProvider(ProviderOutcomeV1.succeeded(payload))
+    service = _service(None, provider=provider)
+    result = service.generate(_command(request_id="req_union_tag_not_found"))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.diagnostics is not None
+    not_found_issues = [
+        issue
+        for issue in result.diagnostics.issues
+        if issue.code == "UNION_TAG_NOT_FOUND"
+    ]
+    assert not_found_issues
+    assert not_found_issues[0].message == _SCHEMA_DIAGNOSTIC_MESSAGES["union_tag_not_found"]
 
 
 def test_candidate_generation_failure_snapshot_diagnostics_invariant() -> None:

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2365,6 +2365,118 @@ def test_definition_invalid_does_not_persist_raw_provider_payload_sentinel() -> 
     assert sentinel not in operation.model_dump_json()
 
 
+RAW_PROVIDER_KEY_SENTINEL = "__RAW_PROVIDER_KEY_SENTINEL__"
+
+
+def _payload_with_raw_extra_provider_keys(load_fixture) -> dict:
+    payload = copy.deepcopy(load_fixture("simple_bruiser"))
+    payload[RAW_PROVIDER_KEY_SENTINEL] = "x"
+    payload["rule_elements"][0][RAW_PROVIDER_KEY_SENTINEL] = "y"
+    return payload
+
+
+def test_extra_forbidden_provider_key_sentinel_sanitized_at_service_and_persistence(
+    load_fixture,
+) -> None:
+    provider = FakeDefinitionProvider(
+        ProviderOutcomeV1.succeeded(_payload_with_raw_extra_provider_keys(load_fixture))
+    )
+    service = _service(None, provider=provider)
+    result = service.generate(_command(request_id="req_raw_key_sanitize"))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.diagnostics is not None
+    diag_json = result.diagnostics.model_dump_json()
+    assert RAW_PROVIDER_KEY_SENTINEL not in diag_json
+    extra_issues = [
+        issue
+        for issue in result.diagnostics.issues
+        if issue.code == "EXTRA_FORBIDDEN"
+    ]
+    assert extra_issues
+    field_paths = {issue.field_path for issue in extra_issues}
+    assert "<unexpected_key>" in field_paths
+    assert "rule_elements[0].<unexpected_key>" in field_paths
+
+    ops = service._generate_operations
+    assert ops is not None
+    operation = ops.get_generate_operation("tests", "req_raw_key_sanitize")
+    assert operation is not None
+    op_json = operation.model_dump_json()
+    assert RAW_PROVIDER_KEY_SENTINEL not in op_json
+
+
+def test_candidate_generation_failure_snapshot_diagnostics_invariant() -> None:
+    from pydantic import ValidationError
+
+    from statblocks_v1.domain.candidate_operations import (
+        CandidateGenerationFailureSnapshotV1,
+        GenerationValidationDiagnosticIssueV1,
+        GenerationValidationDiagnosticPacketV1,
+        GenerationValidationPhaseV1,
+    )
+    from statblocks_v1.domain.receipts import ValidationSeverity
+
+    packet = GenerationValidationDiagnosticPacketV1(
+        phase=GenerationValidationPhaseV1.schema_validation,
+        issue_count=1,
+        issues=[
+            GenerationValidationDiagnosticIssueV1(
+                code="MISSING",
+                severity=ValidationSeverity.error,
+                field_path="identity.name",
+                message="Field required",
+            )
+        ],
+    )
+    CandidateGenerationFailureSnapshotV1(
+        kind="definition_invalid",
+        message="Generated definition failed validation",
+        diagnostics=None,
+    )
+    CandidateGenerationFailureSnapshotV1(
+        kind="definition_invalid",
+        message="Generated definition failed validation",
+        diagnostics=packet,
+    )
+    CandidateGenerationFailureSnapshotV1(
+        kind="provider_refusal", message="nope", diagnostics=None
+    )
+    with pytest.raises(ValidationError, match="definition_invalid"):
+        CandidateGenerationFailureSnapshotV1(
+            kind="provider_refusal", message="nope", diagnostics=packet
+        )
+
+
+def test_raise_for_generation_failure_omits_diagnostics_unless_definition_invalid() -> None:
+    from statblocks_v1.api.http_errors import StatblockV1HTTPError, raise_for_generation_failure
+    from statblocks_v1.domain.candidate_operations import (
+        GenerationValidationDiagnosticIssueV1,
+        GenerationValidationDiagnosticPacketV1,
+        GenerationValidationPhaseV1,
+    )
+    from statblocks_v1.domain.receipts import ValidationSeverity
+
+    packet = GenerationValidationDiagnosticPacketV1(
+        phase=GenerationValidationPhaseV1.schema_validation,
+        issue_count=1,
+        issues=[
+            GenerationValidationDiagnosticIssueV1(
+                code="MISSING",
+                severity=ValidationSeverity.error,
+                field_path="identity.name",
+                message="Field required",
+            )
+        ],
+    )
+    for kind in ("provider_refusal", "unexpected_kind_for_test"):
+        with pytest.raises(StatblockV1HTTPError) as exc:
+            raise_for_generation_failure(
+                GenerationFailureV1(kind, "failure message", diagnostics=packet)
+            )
+        assert exc.value.error.details is None
+
+
 def test_legacy_failed_operation_without_diagnostics_replays_generically(load_fixture) -> None:
     from statblocks_v1.application.repositories import compute_generate_candidate_digest
     from statblocks_v1.domain.candidate_operations import (

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2286,3 +2286,129 @@ def test_replay_missing_candidate_after_op_expiry_raises_410(load_fixture) -> No
             ) from missing
     assert exc.value.details["candidate_id"] == "cand_1"
     assert len(provider.calls) == 1
+
+
+def test_schema_invalid_definition_emits_bounded_schema_diagnostics() -> None:
+    provider = FakeDefinitionProvider(ProviderOutcomeV1.succeeded({"not": "a definition"}))
+    service = _service(None, provider=provider)
+    result = service.generate(_command(request_id="req_schema_invalid"))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "definition_invalid"
+    assert result.diagnostics is not None
+    assert result.diagnostics.phase.value == "schema_validation"
+    assert result.diagnostics.issue_count == len(result.diagnostics.issues)
+    assert result.diagnostics.issues
+    serialized = result.diagnostics.model_dump_json()
+    assert '"input":' not in serialized
+    assert '"ctx":' not in serialized
+
+
+def test_domain_invalid_definition_emits_validator_issues(load_fixture) -> None:
+    service = _service(load_fixture("dangling_multiattack_ref"))
+    result = service.generate(_command(request_id="req_domain_invalid"))
+
+    assert isinstance(result, GenerationFailureV1)
+    assert result.diagnostics is not None
+    assert result.diagnostics.phase.value == "domain_validation"
+    codes = {issue.code for issue in result.diagnostics.issues}
+    assert "UNKNOWN_MULTIATTACK_ELEMENT" in codes
+    assert all(issue.severity.value == "error" for issue in result.diagnostics.issues)
+
+
+def test_definition_invalid_failure_replay_preserves_diagnostics_and_one_provider_call(
+    load_fixture,
+) -> None:
+    provider = FakeDefinitionProvider(load_fixture("dangling_multiattack_ref"))
+    service = _service(None, provider=provider)
+    command = _command(request_id="req_diag_replay")
+    first = service.generate(command)
+    second = service.generate(command)
+
+    assert isinstance(first, GenerationFailureV1)
+    assert isinstance(second, GenerationFailureV1)
+    assert first.diagnostics is not None
+    assert second.diagnostics is not None
+    assert first.diagnostics.model_dump(mode="json") == second.diagnostics.model_dump(
+        mode="json"
+    )
+    assert len(provider.calls) == 1
+
+    ops = service._generate_operations
+    assert ops is not None
+    operation = ops.get_generate_operation("tests", "req_diag_replay")
+    assert operation is not None
+    assert operation.failure is not None
+    assert operation.failure.diagnostics is not None
+    assert (
+        operation.failure.diagnostics.model_dump(mode="json")
+        == first.diagnostics.model_dump(mode="json")
+    )
+    op_json = operation.model_dump_json()
+    assert '"input":' not in op_json
+
+
+def test_definition_invalid_does_not_persist_raw_provider_payload_sentinel() -> None:
+    sentinel = "__DMS_VAL01_RAW_PAYLOAD_SENTINEL__"
+    provider = FakeDefinitionProvider(
+        ProviderOutcomeV1.succeeded({"not": "a definition", "sentinel_probe": sentinel})
+    )
+    service = _service(None, provider=provider)
+    result = service.generate(_command(request_id="req_sentinel_absence"))
+    assert isinstance(result, GenerationFailureV1)
+    blob = result.diagnostics.model_dump_json() if result.diagnostics else ""
+    ops = service._generate_operations
+    assert ops is not None
+    operation = ops.get_generate_operation("tests", "req_sentinel_absence")
+    assert operation is not None
+    assert sentinel not in blob
+    assert sentinel not in operation.model_dump_json()
+
+
+def test_legacy_failed_operation_without_diagnostics_replays_generically(load_fixture) -> None:
+    from statblocks_v1.application.repositories import compute_generate_candidate_digest
+    from statblocks_v1.domain.candidate_operations import (
+        CandidateGenerationFailureSnapshotV1,
+    )
+    from statblocks_v1.infrastructure.memory_repositories import (
+        InMemoryCandidateGenerationOperationRepository,
+        InMemoryCandidateRepository,
+    )
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    candidates = InMemoryCandidateRepository(clock=lambda: now)
+    ops = InMemoryCandidateGenerationOperationRepository(candidates, clock=lambda: now)
+    provider = FakeDefinitionProvider(load_fixture("simple_bruiser"))
+    service = GenerationServiceV1(
+        provider=provider,
+        candidates=candidates,
+        settings=GenerationSettingsV1("test-model", 1, 0, 60),
+        clock=lambda: now,
+        candidate_id_factory=lambda: "cand_legacy",
+        generate_operations=ops,
+    )
+    command = _command(request_id="req_legacy_fail")
+    digest = compute_generate_candidate_digest(command)
+    ops.begin_generate(
+        caller_scope="tests",
+        request_id="req_legacy_fail",
+        request_digest=digest,
+        candidate_id_factory=lambda: "cand_legacy",
+        lease_owner="owner",
+        lease_duration_seconds=30,
+    )
+    legacy = CandidateGenerationFailureSnapshotV1(
+        kind="definition_invalid", message="Generated definition failed validation"
+    )
+    ops.fail_generate(
+        caller_scope="tests",
+        request_id="req_legacy_fail",
+        request_digest=digest,
+        lease_owner="owner",
+        failure=legacy,
+    )
+    result = service.generate(command)
+    assert isinstance(result, GenerationFailureV1)
+    assert result.kind == "definition_invalid"
+    assert result.diagnostics is None
+    assert len(provider.calls) == 0

--- a/tests/statblocks_v1/test_memory_repositories.py
+++ b/tests/statblocks_v1/test_memory_repositories.py
@@ -820,6 +820,74 @@ def test_generate_ops_reserve_complete_conflict_and_takeover(load_fixture):
     assert failed.failure.kind == "provider_refusal"
 
 
+def test_fail_generate_persists_optional_diagnostics_round_trip(load_fixture):
+    from statblocks_v1.application.commands import (
+        CallerProvenanceV1,
+        GenerateStatblockCommandV1,
+        SourceSnapshotV1,
+    )
+    from statblocks_v1.application.repositories import compute_generate_candidate_digest
+    from statblocks_v1.domain.candidate_operations import (
+        CandidateGenerationFailureSnapshotV1,
+        GenerationValidationDiagnosticIssueV1,
+        GenerationValidationDiagnosticPacketV1,
+        GenerationValidationPhaseV1,
+    )
+    from statblocks_v1.domain.profiles import RulesetRef
+    from statblocks_v1.domain.receipts import ValidationSeverity
+    from statblocks_v1.infrastructure.memory_repositories import (
+        InMemoryCandidateGenerationOperationRepository,
+        InMemoryCandidateRepository,
+    )
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    candidates = InMemoryCandidateRepository(clock=lambda: now)
+    ops = InMemoryCandidateGenerationOperationRepository(candidates, clock=lambda: now)
+    command = GenerateStatblockCommandV1(
+        request_id="req_diag_store",
+        ruleset=RulesetRef(system="dnd5e", edition="2024"),
+        source=SourceSnapshotV1(name_hint="X", description="Y"),
+        caller=CallerProvenanceV1(caller_scope="tests"),
+    )
+    digest = compute_generate_candidate_digest(command)
+    ops.begin_generate(
+        caller_scope="tests",
+        request_id="req_diag_store",
+        request_digest=digest,
+        candidate_id_factory=lambda: "cand_diagstr01",
+        lease_owner="owner",
+        lease_duration_seconds=30,
+    )
+    packet = GenerationValidationDiagnosticPacketV1(
+        phase=GenerationValidationPhaseV1.schema_validation,
+        issue_count=1,
+        issues=[
+            GenerationValidationDiagnosticIssueV1(
+                code="MISSING",
+                severity=ValidationSeverity.error,
+                field_path="identity.name",
+                message="Field required",
+            )
+        ],
+    )
+    snapshot = ops.fail_generate(
+        caller_scope="tests",
+        request_id="req_diag_store",
+        request_digest=digest,
+        lease_owner="owner",
+        failure=CandidateGenerationFailureSnapshotV1(
+            kind="definition_invalid",
+            message="Generated definition failed validation",
+            diagnostics=packet,
+        ),
+    )
+    assert snapshot.diagnostics == packet
+    loaded = ops.get_generate_operation("tests", "req_diag_store")
+    assert loaded is not None
+    assert loaded.failure is not None
+    assert loaded.failure.diagnostics == packet
+
+
 def test_generate_ops_concurrent_complete_converges(load_fixture):
     from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
## Summary

Implements **DMS-VAL-01** per DungeonMindBuddy's checked-in handoff `HANDOFF-dms-generation-validation-diagnostics` (PR Drakosfire/DungeonMindBuddy#449). Parent evidence: R0-A Mireward Latchling dogfood `FAIL_PRODUCT` — a real generation failure collapsed to `Generated definition failed validation`, leaving the operator with no actionable cause.

Generated definitions rejected before candidate creation now emit a **bounded typed diagnostic packet** on HTTP 422 `validation_failed`, persisted on the terminal failure snapshot so same-key replay exposes the identical packet with no second provider call.

## Diagnostic packet contract

`GenerationValidationDiagnosticPacketV1`: `schema_version` discriminator, `phase` (`schema_validation` | `domain_validation`), `issue_count`, and bounded `issues[]` (≤32 entries; `field_path`≤256, `code`≤64, `message`≤512, `suggested_resolution`≤512), deterministic ordering.

- **schema_validation** derives from Pydantic `ValidationError` via `errors(include_input=False, include_url=False)`; severity=`error`; `suggested_resolution` omitted; stable UPPER_SNAKE codes normalized from pydantic error types.
- **domain_validation** derives from error-severity `ValidationReceiptV1.issues`.
- Normalization failure **fails closed**: `diagnostics=None`, generic public message retained.
- Packet persisted as optional field on `CandidateGenerationFailureSnapshotV1` — **legacy records without it load and replay generically**.
- **Replay derives the packet from the persisted snapshot**; provider call count unchanged; changed-digest replay remains 409.
- `raise_for_generation_failure` attaches the packet to `error.details` only when present; unknown failure kinds still fail closed with no details.

## Security

Raw provider payload, `ValidationError.input`, provider exception objects, and prompts are never serialized into responses, logs, or durable operation records. Proven by sentinel test (`__DMS_VAL01_RAW_PAYLOAD_SENTINEL__`) across diagnostics JSON, operation record JSON, and HTTP response text, plus `'"input":'` / `'"ctx":'` absence assertions.

## Verification (all re-run by reviewer, not just the implementer)

| Gate | Result |
|---|---|
| `uv run pytest tests/statblocks_v1 -q` (project venv, lock pydantic 2.10.6) | **276 passed, 15 skipped, 0 failed** |
| `./scripts/run_statblocks_v1_tests.sh -q` (isolated lane) | **0 failures** (lane repinned to lock pydantic on main) |
| Firestore integration | 2 passed, 13 skipped — emulator not configured in this environment (honest skips, incl. new diagnostics round-trip test) |
| `git diff --check main..HEAD` | clean |

Key proofs: first-vs-replay packet equality + one provider call (`test_definition_invalid_failure_replay_preserves_diagnostics_and_one_provider_call`); generate **and** revise share the envelope contract (`test_definition_invalid_generate_and_revise_emit_matching_diagnostic_envelopes`); legacy snapshot without diagnostics replays generically; memory + Firestore round-trips.

## Stacks on (already on main)

- `01abf2f` schema artifact regeneration (fail-closed blocker for clean checkouts)
- `6842cb8` OpenAPI contract artifact regeneration (same emission-drift class; TS client byte-identical except fingerprint)
- `8aff6ea` isolated-lane pydantic repin

## Explicitly not done (per handoff §5)

No repair retry, no second provider call, no validation relaxation, no prompt tuning, no schema/compiler changes, no DungeonMindBuddy code. Buddy propagation + Workbench rendering is the named successor (**BUDDY-VAL-01**).

## Reviewer protocol (handoff §10)

1. Reproduce both schema and domain invalidity — `test_schema_invalid_definition_emits_bounded_schema_diagnostics`, `test_domain_invalid_definition_emits_validator_issues`.
2. Inspect the persisted operation record, not only the HTTP body — replay test asserts `operation.failure.diagnostics` equals response packet.
3. Replay exact request, compare semantic packet equality; confirm one provider call.
4. Search response/logs/record for sentinel raw input.
5. Load a legacy failed record without diagnostics.
6. Confirm revise shares the invariant.

Made with [Cursor](https://cursor.com)