### PR TITLE
feat(statblocks_v1): server-owned derived math (prompt v5)

### DIFF
--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/candidate-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/candidate-response.json
@@ -180,6 +180,6 @@
     "mode": "generation_candidate",
     "status": "valid",
     "validated_at": "2026-01-01T00:00:00Z",
-    "validator_version": "statblock-validator-v1.1"
+    "validator_version": "statblock-validator-v1.2"
   }
 }

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/candidate-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/candidate-response.json
@@ -160,7 +160,7 @@
     "latency_ms": 0,
     "model": "fixture-model",
     "output_tokens": null,
-    "prompt_version": "statblock-generation-prompt-v4",
+    "prompt_version": "statblock-generation-prompt-v5",
     "provider": "fake",
     "provider_request_id": null,
     "provider_response_id": null,

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/create-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/create-response.json
@@ -176,7 +176,7 @@
       "mode": "persistence",
       "status": "valid",
       "validated_at": "2026-01-01T00:00:00Z",
-      "validator_version": "statblock-validator-v1.1"
+      "validator_version": "statblock-validator-v1.2"
     }
   },
   "statblock": {

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/errors.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/errors.json
@@ -18,7 +18,7 @@
         "mode": "persistence",
         "status": "invalid",
         "validated_at": "2026-01-01T00:00:00Z",
-        "validator_version": "statblock-validator-v1.1"
+        "validator_version": "statblock-validator-v1.2"
       }
     },
     "message": "Definition is not persistence-ready"

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/exact-revision-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/exact-revision-response.json
@@ -175,6 +175,6 @@
     "mode": "persistence",
     "status": "valid",
     "validated_at": "2026-01-01T00:00:00Z",
-    "validator_version": "statblock-validator-v1.1"
+    "validator_version": "statblock-validator-v1.2"
   }
 }

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/revise-replay-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/revise-replay-response.json
@@ -154,7 +154,7 @@
     "request_id": "fixture-revise-source-def-1",
     "provider": "fake",
     "model": "test-model",
-    "prompt_version": "statblock-generation-prompt-v4",
+    "prompt_version": "statblock-generation-prompt-v5",
     "schema_version": "statblock-openai-strict-compiler-v1",
     "schema_fingerprint": "sha256:aa2b662d85d6652719ed213cee4190c84366c2d72affbbdccdaa0d5ea5c139f0",
     "generated_at": "2026-01-01T12:00:00Z",

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/revise-replay-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/revise-replay-response.json
@@ -144,7 +144,7 @@
   "validation_receipt": {
     "status": "valid",
     "mode": "generation_candidate",
-    "validator_version": "statblock-validator-v1.1+statblock-key-preservation-v1",
+    "validator_version": "statblock-validator-v1.2+statblock-key-preservation-v1",
     "canonicalizer_version": "statblock-canonicalizer-v1",
     "issues": [],
     "definition_digest": "sha256:265da39c72a5275bfb81315034b972ddae4aca261a683fa9ecc70a4839e91c44",

--- a/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/validate-response.json
+++ b/Docs/Design/fixtures/dungeonbuddy-statblock-v1-api/validate-response.json
@@ -7,6 +7,6 @@
     "mode": "editor_preview",
     "status": "valid",
     "validated_at": "2026-01-01T00:00:00Z",
-    "validator_version": "statblock-validator-v1.1"
+    "validator_version": "statblock-validator-v1.2"
   }
 }

--- a/scripts/statblock_prompt_eval.py
+++ b/scripts/statblock_prompt_eval.py
@@ -45,6 +45,7 @@ from statblocks_v1.application.schema_compiler import (  # noqa: E402
     compile_openai_definition_schema,
 )
 from statblocks_v1.application.settings import GenerationSettingsV1  # noqa: E402
+from statblocks_v1.domain.derived import compute_derived_values  # noqa: E402
 from statblocks_v1.domain.profiles import RulesetEdition, RulesetRef, RulesetSystem  # noqa: E402
 from statblocks_v1.domain.receipts import ValidationMode, ValidationSeverity  # noqa: E402
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1  # noqa: E402
@@ -244,6 +245,7 @@ def _run_trial(
     arm: str,
     trial: int,
     dump_dir: Path | None = None,
+    server_derived: bool = False,
 ) -> TrialResult:
     keep_descriptions, use_real_prompt, include_examples = _arm_config(arm)
     schema = _compiled_schema_with_descriptions(keep_descriptions=keep_descriptions)
@@ -280,6 +282,11 @@ def _run_trial(
         result.outcome_kind = "parse_failure"
         result.message = str(exc.errors()[0].get("msg", "model validation failed"))
         return result
+
+    if server_derived:
+        # Simulate production: GenerationServiceV1 computes derived values before
+        # validation, so advisory provider arithmetic never reaches the receipt.
+        definition, _derived_adjustments = compute_derived_values(definition)
 
     result.error_codes = _error_codes_from_definition(definition)
     return result
@@ -369,6 +376,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Write each raw provider payload to this directory for post-mortem inspection.",
     )
     parser.add_argument(
+        "--server-derived",
+        action="store_true",
+        help="Apply production server-owned derivation before validating (what GenerationServiceV1 stores).",
+    )
+    parser.add_argument(
         "--yes",
         action="store_true",
         help="Confirm live OpenAI calls when the plan exceeds 20 API calls.",
@@ -428,6 +440,7 @@ def main(argv: list[str] | None = None) -> None:
                     arm=arm,
                     trial=trial,
                     dump_dir=dump_dir,
+                    server_derived=args.server_derived,
                 )
                 all_results.append(result)
                 if result.outcome_kind == ProviderOutcomeKind.success.value:

--- a/statblocks_v1/application/generation.py
+++ b/statblocks_v1/application/generation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import math
 import os
 import re
@@ -98,6 +99,7 @@ from statblocks_v1.domain.resources import (
     GeneratedStatblockCandidateV1,
     GenerationReceiptV1,
 )
+from statblocks_v1.domain.derived import compute_derived_values
 from statblocks_v1.domain.rule_elements import RuleElement, StatblockDefinitionV1
 from statblocks_v1.domain.validation import validate_definition
 
@@ -106,6 +108,8 @@ CandidateIdFactory = Callable[[], str]
 LeaseOwnerFactory = Callable[[], str]
 
 KEY_PRESERVATION_PASS_VERSION = "statblock-key-preservation-v1"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DefinitionResolver(Protocol):
@@ -931,6 +935,24 @@ class GenerationServiceV1:
             return GenerationFailureV1(
                 "ruleset_mismatch",
                 "Generated definition ruleset does not match the requested ruleset",
+            )
+
+        # Server owns derived math: provider-emitted proficiency/derived values
+        # are advisory and overwritten before validation and storage.
+        definition, derived_adjustments = compute_derived_values(definition)
+        if derived_adjustments:
+            _LOGGER.info(
+                "statblocks_v1_derived_values_adjusted",
+                extra={
+                    "adjustments": [
+                        {
+                            "field_path": adjustment.field_path,
+                            "provider_value": adjustment.provider_value,
+                            "computed_value": adjustment.computed_value,
+                        }
+                        for adjustment in derived_adjustments
+                    ]
+                },
             )
 
         now = self._clock()

--- a/statblocks_v1/application/prompts.py
+++ b/statblocks_v1/application/prompts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from statblocks_v1.application.commands import GenerateStatblockCommandV1, ReviseStatblockCommandV1
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 
-PROMPT_VERSION = "statblock-generation-prompt-v4"
+PROMPT_VERSION = "statblock-generation-prompt-v5"
 
 WORKED_EXAMPLES = """WORKED EXAMPLES - field shapes are normative; values are illustrative, compute yours per creature:
 - recharge usage: {"kind":"recharge","recharge_range":{"minimum":5,"maximum":6},"uses":null,"resource_key":null,"refresh_text":null}
@@ -12,7 +12,6 @@ WORKED_EXAMPLES = """WORKED EXAMPLES - field shapes are normative; values are il
 - resource usage spending from a declared pool: {"kind":"resource","recharge_range":null,"uses":null,"resource_key":"legendary_actions","refresh_text":null}
 - multiattack: mechanic.kind "multiattack" with "sequences":[{"element_key":"bite","count":1,"choice_group":null},{"element_key":"claw","count":2,"choice_group":null}] where "bite" and "claw" are other rule_elements keys whose mechanics are attacks - never the multiattack's own key or another multiattack.
 - legendary action: NOT a multiattack. Use mechanic.kind "attack", section "legendary_action", activation.kind "legendary", usage.kind "resource", and costs against the declared legendary pool.
-- standard derivation: strength 16 gives modifier +3; with proficiency_bonus +2, {"skill":"athletics","ability":"strength","value":5,"derivation":"standard","note":null}. If the value you want does not equal ability modifier + proficiency bonus (or + twice proficiency for expertise), set derivation "explicit_override"; never force mismatched arithmetic into "standard".
 """
 
 
@@ -47,11 +46,11 @@ USAGE FIELDS - usage.kind decides which sibling fields may appear:
   manual                         recharge_range null; uses and resource_key optional
 Never set recharge_range on any kind other than recharge.
 
-DERIVED MATH - these are checked arithmetically:
-- challenge.proficiency_bonus must match challenge.rating on the standard 5e table.
-- senses.passive_perception must equal 10 + the Perception skill value when a Perception skill entry exists.
-- Skills and saves with derivation "standard" equal ability modifier + proficiency bonus; "expertise" adds proficiency twice; use "explicit_override" for anything else.
-- vitality.hit_points: method "formula" sets formula and leaves fixed_value null; method "fixed" sets fixed_value and leaves formula null. displayed_average, when set, equals the formula average.
+DERIVED MATH - the server computes; you declare intent:
+- Skills and saves with derivation "standard" or "expertise" are computed from the ability scores and challenge rating you set; the value you emit is advisory and will be overwritten. "explicit_override" is the only derivation whose value is trusted - use it for intentional exceptions.
+- challenge.proficiency_bonus (from rating) and vitality.hit_points.displayed_average (from the dice formula) are likewise server-computed.
+- senses.passive_perception is NOT server-computed: it must equal 10 + the Perception skill value when a Perception skill entry exists.
+- vitality.hit_points: method "formula" sets formula and leaves fixed_value null; method "fixed" sets fixed_value and leaves formula null.
 
 REFERENCES - declare before you reference:
 - Multiattack sequences reference other rule_elements keys; a multiattack may not reference itself or another multiattack.
@@ -83,7 +82,7 @@ ESCAPE HATCH
 1. Exactly one armor class has default=true.
 2. Every usage object matches its kind's row above, and every recharge usage sets recharge_range.
 3. Every key you reference is declared somewhere in the definition.
-4. proficiency_bonus matches CR, and passive_perception matches Perception.
+4. passive_perception equals 10 + the Perception skill value when a Perception entry exists.
 5. Every human_adjudicated mechanic has automation_support "manual".
 """)
     return "\n".join(parts)

--- a/statblocks_v1/domain/derived.py
+++ b/statblocks_v1/domain/derived.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pydantic import ValidationError
+
 from statblocks_v1.domain.primitives import AbilityName, DiceExpression
 from statblocks_v1.domain.profiles import AbilityScores, ProficiencyDerivation
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
@@ -111,7 +113,12 @@ def compute_derived_values(
     hit_points = definition.vitality.hit_points
     if hit_points.formula is not None:
         average = hit_point_average(hit_points.formula)
-        if hit_points.displayed_average != average:
+        # displayed_average is bounded (>= 1) while DiceExpression.modifier is
+        # not: a pathological formula (1d2-2) can average below the field's
+        # floor. Skip the write; the authored value stays and the validator's
+        # mismatch error keeps the weird formula visible instead of storing a
+        # contract-violating number.
+        if average >= 1 and hit_points.displayed_average != average:
             adjustments.append(
                 DerivedValueAdjustmentV1(
                     "vitality.hit_points.displayed_average",
@@ -133,4 +140,12 @@ def compute_derived_values(
             "vitality": definition.vitality.model_copy(update={"hit_points": hit_points}),
         }
     )
+    try:
+        # model_copy skips validation; revalidate so a computed value can never
+        # smuggle a contract violation into the stored candidate.
+        derived = StatblockDefinitionV1.model_validate(derived.model_dump(mode="json"))
+    except ValidationError:
+        # Fail safe: keep the provider's original (which already parsed) and let
+        # domain validation report the raw state on the receipt instead.
+        return definition, []
     return derived, adjustments

--- a/statblocks_v1/domain/derived.py
+++ b/statblocks_v1/domain/derived.py
@@ -1,0 +1,136 @@
+"""Server-owned derived values for the v1 statblock contract.
+
+The LLM authors intent (ability scores, challenge rating, derivation kinds,
+dice formulas). Every value that is a deterministic function of that intent
+is computed by the server: provider-emitted numbers for these fields are
+advisory and are overwritten before validation and storage. This module is
+the single source of truth for the derivation math; ``validation.py`` imports
+it to check (rather than re-implement) the same rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from statblocks_v1.domain.primitives import AbilityName, DiceExpression
+from statblocks_v1.domain.profiles import AbilityScores, ProficiencyDerivation
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+CR_PROFICIENCY_BONUS = {
+    "0": 2,
+    "1/8": 2,
+    "1/4": 2,
+    "1/2": 2,
+    **{str(cr): 2 for cr in range(1, 5)},
+    **{str(cr): 3 for cr in range(5, 9)},
+    **{str(cr): 4 for cr in range(9, 13)},
+    **{str(cr): 5 for cr in range(13, 17)},
+    **{str(cr): 6 for cr in range(17, 21)},
+    **{str(cr): 7 for cr in range(21, 25)},
+    **{str(cr): 8 for cr in range(25, 29)},
+    **{str(cr): 9 for cr in range(29, 31)},
+}
+
+
+def ability_modifier(abilities: AbilityScores, ability: AbilityName) -> int:
+    return (getattr(abilities, ability.value) - 10) // 2
+
+
+def expected_proficiency_bonus(
+    abilities: AbilityScores,
+    ability: AbilityName,
+    derivation: ProficiencyDerivation,
+    proficiency_bonus: int,
+) -> int | None:
+    """Expected save/skill value, or None when derivation keeps authored authority."""
+    modifier = ability_modifier(abilities, ability)
+    if derivation is ProficiencyDerivation.standard:
+        return modifier + proficiency_bonus
+    if derivation is ProficiencyDerivation.expertise:
+        return modifier + (2 * proficiency_bonus)
+    return None
+
+
+def hit_point_average(formula: DiceExpression) -> int:
+    return formula.count * (formula.die + 1) // 2 + formula.modifier
+
+
+@dataclass(frozen=True)
+class DerivedValueAdjustmentV1:
+    """One provider-emitted value overwritten by server computation."""
+
+    field_path: str
+    provider_value: int | None
+    computed_value: int
+
+
+def compute_derived_values(
+    definition: StatblockDefinitionV1,
+) -> tuple[StatblockDefinitionV1, list[DerivedValueAdjustmentV1]]:
+    """Return the definition with every server-owned value computed, plus adjustments.
+
+    Server-owned: challenge.proficiency_bonus (from rating); saving throw and
+    skill values for standard/expertise derivations (explicit_override keeps
+    authored authority); vitality.hit_points.displayed_average (from the dice
+    formula, when present). senses.passive_perception is deliberately excluded:
+    traits can legitimately raise it, so it stays authored-and-validated.
+    """
+    adjustments: list[DerivedValueAdjustmentV1] = []
+
+    challenge = definition.challenge
+    table_bonus = CR_PROFICIENCY_BONUS.get(challenge.rating)
+    if table_bonus is not None and challenge.proficiency_bonus != table_bonus:
+        adjustments.append(
+            DerivedValueAdjustmentV1(
+                "challenge.proficiency_bonus", challenge.proficiency_bonus, table_bonus
+            )
+        )
+        challenge = challenge.model_copy(update={"proficiency_bonus": table_bonus})
+    proficiency_bonus = challenge.proficiency_bonus
+
+    def _derive_items(items, path_prefix):
+        derived_items = []
+        for index, item in enumerate(items):
+            expected = expected_proficiency_bonus(
+                definition.abilities, item.ability, item.derivation, proficiency_bonus
+            )
+            if expected is not None and item.value != expected:
+                adjustments.append(
+                    DerivedValueAdjustmentV1(
+                        f"{path_prefix}[{index}].value", item.value, expected
+                    )
+                )
+                item = item.model_copy(update={"value": expected})
+            derived_items.append(item)
+        return derived_items
+
+    proficiencies = definition.proficiencies
+    saving_throws = _derive_items(proficiencies.saving_throws, "proficiencies.saving_throws")
+    skills = _derive_items(proficiencies.skills, "proficiencies.skills")
+
+    hit_points = definition.vitality.hit_points
+    if hit_points.formula is not None:
+        average = hit_point_average(hit_points.formula)
+        if hit_points.displayed_average != average:
+            adjustments.append(
+                DerivedValueAdjustmentV1(
+                    "vitality.hit_points.displayed_average",
+                    hit_points.displayed_average,
+                    average,
+                )
+            )
+            hit_points = hit_points.model_copy(update={"displayed_average": average})
+
+    if not adjustments:
+        return definition, adjustments
+
+    derived = definition.model_copy(
+        update={
+            "challenge": challenge,
+            "proficiencies": proficiencies.model_copy(
+                update={"saving_throws": saving_throws, "skills": skills}
+            ),
+            "vitality": definition.vitality.model_copy(update={"hit_points": hit_points}),
+        }
+    )
+    return derived, adjustments

--- a/statblocks_v1/domain/receipts.py
+++ b/statblocks_v1/domain/receipts.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from statblocks_v1.domain.primitives import StrictModel
 
-VALIDATOR_VERSION = "statblock-validator-v1.1"
+VALIDATOR_VERSION = "statblock-validator-v1.2"
 
 
 class ValidationMode(str, Enum):

--- a/statblocks_v1/domain/validation.py
+++ b/statblocks_v1/domain/validation.py
@@ -12,6 +12,7 @@ from statblocks_v1.domain.derived import (
     CR_PROFICIENCY_BONUS as _CR_PROFICIENCY_BONUS,
     ability_modifier as _ability_modifier,
     expected_proficiency_bonus as _expected_proficiency_bonus,
+    hit_point_average as _hit_point_average,
 )
 from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.primitives import (
@@ -170,9 +171,16 @@ def _validate_profiles(definition: StatblockDefinitionV1, issue: IssueEmitter) -
             "vitality.hit_points",
             "Fixed HP requires fixed_value and must not include formula.",
         )
-    if hp.formula and hp.displayed_average is not None:
-        average = hp.formula.count * (hp.formula.die + 1) // 2 + hp.formula.modifier
-        if hp.displayed_average != average:
+    if hp.formula is not None:
+        average = _hit_point_average(hp.formula)
+        if average < 1:
+            issue(
+                "HP_FORMULA_AVERAGE_INVALID",
+                ValidationSeverity.error,
+                "vitality.hit_points.formula",
+                "Dice formula averages below 1; it cannot yield a positive HP value.",
+            )
+        elif hp.displayed_average is not None and hp.displayed_average != average:
             issue(
                 "HP_DISPLAYED_AVERAGE_MISMATCH",
                 ValidationSeverity.error,

--- a/statblocks_v1/domain/validation.py
+++ b/statblocks_v1/domain/validation.py
@@ -8,6 +8,11 @@ from collections.abc import Callable, Iterable
 from datetime import datetime
 
 from statblocks_v1.domain.canonicalization import CANONICALIZER_VERSION
+from statblocks_v1.domain.derived import (
+    CR_PROFICIENCY_BONUS as _CR_PROFICIENCY_BONUS,
+    ability_modifier as _ability_modifier,
+    expected_proficiency_bonus as _expected_proficiency_bonus,
+)
 from statblocks_v1.domain.digests import compute_definition_digest
 from statblocks_v1.domain.primitives import (
     AbilityName,
@@ -52,20 +57,6 @@ from statblocks_v1.domain.rule_elements import (
 
 IssueEmitter = Callable[[str, ValidationSeverity, str, str, str | None], None]
 
-_CR_PROFICIENCY_BONUS = {
-    "0": 2,
-    "1/8": 2,
-    "1/4": 2,
-    "1/2": 2,
-    **{str(cr): 2 for cr in range(1, 5)},
-    **{str(cr): 3 for cr in range(5, 9)},
-    **{str(cr): 4 for cr in range(9, 13)},
-    **{str(cr): 5 for cr in range(13, 17)},
-    **{str(cr): 6 for cr in range(17, 21)},
-    **{str(cr): 7 for cr in range(21, 25)},
-    **{str(cr): 8 for cr in range(25, 29)},
-    **{str(cr): 9 for cr in range(29, 31)},
-}
 _SECTION_ACTIVATIONS = {
     RuleSection.action: {ActivationKind.action},
     RuleSection.bonus_action: {ActivationKind.bonus_action},
@@ -240,24 +231,6 @@ def _normalize_skill_name(skill: str) -> str:
     """Match canonicalization: Unicode NFC, then casefold for identity."""
 
     return unicodedata.normalize("NFC", skill).casefold()
-
-
-def _ability_modifier(abilities: AbilityScores, ability: AbilityName) -> int:
-    return (getattr(abilities, ability.value) - 10) // 2
-
-
-def _expected_proficiency_bonus(
-    abilities: AbilityScores,
-    ability: AbilityName,
-    derivation: ProficiencyDerivation,
-    proficiency_bonus: int,
-) -> int | None:
-    modifier = _ability_modifier(abilities, ability)
-    if derivation is ProficiencyDerivation.standard:
-        return modifier + proficiency_bonus
-    if derivation is ProficiencyDerivation.expertise:
-        return modifier + (2 * proficiency_bonus)
-    return None
 
 
 def _validate_proficiency_derivations(

--- a/tests/statblocks_v1/test_derived.py
+++ b/tests/statblocks_v1/test_derived.py
@@ -6,7 +6,7 @@ from statblocks_v1.domain.profiles import (
     SavingThrowBonus,
     SkillBonus,
 )
-from statblocks_v1.domain.primitives import AbilityName
+from statblocks_v1.domain.primitives import AbilityName, DiceExpression
 from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
 
 
@@ -200,3 +200,29 @@ def test_consistent_definition_is_returned_unchanged(load_fixture) -> None:
 
     assert derived is definition
     assert adjustments == []
+
+
+def test_impossible_formula_average_is_not_written(load_fixture) -> None:
+    base = _definition(load_fixture)
+    for emitted in (1, None):
+        definition = base.model_copy(
+            update={
+                "vitality": base.vitality.model_copy(
+                    update={
+                        "hit_points": base.vitality.hit_points.model_copy(
+                            update={
+                                "formula": DiceExpression(count=1, die=2, modifier=-2),
+                                "displayed_average": emitted,
+                            }
+                        )
+                    }
+                )
+            }
+        )
+
+        derived, adjustments = compute_derived_values(definition)
+
+        # 1d2-2 averages -1, below displayed_average's floor: the write is
+        # skipped and the authored value stands for the validator to flag.
+        assert derived.vitality.hit_points.displayed_average == emitted
+        assert adjustments == []

--- a/tests/statblocks_v1/test_derived.py
+++ b/tests/statblocks_v1/test_derived.py
@@ -1,0 +1,202 @@
+"""Server-owned derived values: provider-emitted numbers are advisory."""
+
+from statblocks_v1.domain.derived import compute_derived_values
+from statblocks_v1.domain.profiles import (
+    ProficiencyDerivation,
+    SavingThrowBonus,
+    SkillBonus,
+)
+from statblocks_v1.domain.primitives import AbilityName
+from statblocks_v1.domain.rule_elements import StatblockDefinitionV1
+
+
+def _definition(load_fixture) -> StatblockDefinitionV1:
+    return StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+
+
+def _with_proficiencies(
+    definition: StatblockDefinitionV1,
+    *,
+    skills: list[SkillBonus] | None = None,
+    saving_throws: list[SavingThrowBonus] | None = None,
+) -> StatblockDefinitionV1:
+    return definition.model_copy(
+        update={
+            "proficiencies": definition.proficiencies.model_copy(
+                update={
+                    "skills": skills if skills is not None else definition.proficiencies.skills,
+                    "saving_throws": (
+                        saving_throws
+                        if saving_throws is not None
+                        else definition.proficiencies.saving_throws
+                    ),
+                }
+            )
+        }
+    )
+
+
+def test_standard_skill_value_is_recomputed(load_fixture) -> None:
+    definition = _with_proficiencies(
+        _definition(load_fixture),
+        skills=[
+            SkillBonus(
+                skill="Athletics",
+                ability=AbilityName.strength,
+                value=7,
+                derivation=ProficiencyDerivation.standard,
+            )
+        ],
+    )
+
+    derived, adjustments = compute_derived_values(definition)
+
+    # STR 18 (+4) with CR 3 proficiency bonus (+2) is +6, not the emitted 7.
+    assert derived.proficiencies.skills[0].value == 6
+    assert [
+        (a.field_path, a.provider_value, a.computed_value) for a in adjustments
+    ] == [("proficiencies.skills[0].value", 7, 6)]
+
+
+def test_expertise_save_value_is_recomputed(load_fixture) -> None:
+    definition = _with_proficiencies(
+        _definition(load_fixture),
+        saving_throws=[
+            SavingThrowBonus(
+                ability=AbilityName.strength,
+                value=99,
+                derivation=ProficiencyDerivation.expertise,
+            )
+        ],
+    )
+
+    derived, adjustments = compute_derived_values(definition)
+
+    # Expertise: +4 modifier plus double proficiency (+4) = +8.
+    assert derived.proficiencies.saving_throws[0].value == 8
+    assert [
+        (a.field_path, a.provider_value, a.computed_value) for a in adjustments
+    ] == [("proficiencies.saving_throws[0].value", 99, 8)]
+
+
+def test_explicit_override_keeps_authored_authority(load_fixture) -> None:
+    definition = _with_proficiencies(
+        _definition(load_fixture),
+        skills=[
+            SkillBonus(
+                skill="Intimidation",
+                ability=AbilityName.charisma,
+                value=9,
+                derivation=ProficiencyDerivation.explicit_override,
+            )
+        ],
+    )
+
+    derived, adjustments = compute_derived_values(definition)
+
+    assert derived.proficiencies.skills[0].value == 9
+    assert adjustments == []
+
+
+def test_proficiency_bonus_is_recomputed_from_rating_and_derivations_follow(
+    load_fixture,
+) -> None:
+    definition = _definition(load_fixture).model_copy(
+        update={"challenge": _definition(load_fixture).challenge.model_copy(
+            update={"proficiency_bonus": 9}
+        )}
+    )
+    definition = _with_proficiencies(
+        definition,
+        skills=[
+            SkillBonus(
+                skill="Athletics",
+                ability=AbilityName.strength,
+                value=13,
+                derivation=ProficiencyDerivation.standard,
+            )
+        ],
+    )
+
+    derived, adjustments = compute_derived_values(definition)
+
+    # Rating "3" owns proficiency bonus +2; the standard skill derives against
+    # the corrected bonus (+4 modifier + 2), not the emitted +9.
+    assert derived.challenge.proficiency_bonus == 2
+    assert derived.proficiencies.skills[0].value == 6
+    paths = [a.field_path for a in adjustments]
+    assert paths == ["challenge.proficiency_bonus", "proficiencies.skills[0].value"]
+
+
+def test_unknown_rating_preserves_authored_bonus(load_fixture) -> None:
+    base = _definition(load_fixture)
+    definition = base.model_copy(
+        update={
+            "challenge": base.challenge.model_copy(
+                update={"rating": "mythic", "proficiency_bonus": 7}
+            )
+        }
+    )
+
+    derived, adjustments = compute_derived_values(definition)
+
+    assert derived.challenge.proficiency_bonus == 7
+    assert adjustments == []
+
+
+def test_displayed_average_is_recomputed_from_formula(load_fixture) -> None:
+    base = _definition(load_fixture)
+    for emitted in (999, None):
+        definition = base.model_copy(
+            update={
+                "vitality": base.vitality.model_copy(
+                    update={
+                        "hit_points": base.vitality.hit_points.model_copy(
+                            update={"displayed_average": emitted}
+                        )
+                    }
+                )
+            }
+        )
+
+        derived, adjustments = compute_derived_values(definition)
+
+        # 8d10+24 averages 68 regardless of the emitted value (or its absence).
+        assert derived.vitality.hit_points.displayed_average == 68
+        assert [
+            (a.field_path, a.provider_value, a.computed_value) for a in adjustments
+        ] == [("vitality.hit_points.displayed_average", emitted, 68)]
+
+
+def test_fixed_hit_point_method_leaves_displayed_average_alone(load_fixture) -> None:
+    base = _definition(load_fixture)
+    definition = base.model_copy(
+        update={
+            "vitality": base.vitality.model_copy(
+                update={
+                    "hit_points": base.vitality.hit_points.model_copy(
+                        update={
+                            "method": "fixed",
+                            "formula": None,
+                            "fixed_value": 68,
+                            "displayed_average": None,
+                        }
+                    )
+                }
+            )
+        }
+    )
+
+    derived, adjustments = compute_derived_values(definition)
+
+    assert derived.vitality.hit_points.displayed_average is None
+    assert adjustments == []
+
+
+def test_consistent_definition_is_returned_unchanged(load_fixture) -> None:
+    definition = _definition(load_fixture)
+
+    derived, adjustments = compute_derived_values(definition)
+
+    assert derived is definition
+    assert adjustments == []

--- a/tests/statblocks_v1/test_derived.py
+++ b/tests/statblocks_v1/test_derived.py
@@ -223,6 +223,7 @@ def test_impossible_formula_average_is_not_written(load_fixture) -> None:
         derived, adjustments = compute_derived_values(definition)
 
         # 1d2-2 averages -1, below displayed_average's floor: the write is
-        # skipped and the authored value stands for the validator to flag.
+        # skipped and the authored value stands; domain validation flags the
+        # pathological formula itself via HP_FORMULA_AVERAGE_INVALID.
         assert derived.vitality.hit_points.displayed_average == emitted
         assert adjustments == []

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2619,3 +2619,41 @@ def test_legacy_failed_operation_without_diagnostics_replays_generically(load_fi
     assert result.kind == "definition_invalid"
     assert result.diagnostics is None
     assert len(provider.calls) == 0
+
+
+def test_generate_server_computes_derived_values(load_fixture) -> None:
+    payload = load_fixture("simple_bruiser")
+    payload["challenge"]["proficiency_bonus"] = 9
+    payload["proficiencies"]["skills"] = [
+        {
+            "skill": "Athletics",
+            "ability": "strength",
+            "value": 7,
+            "derivation": "standard",
+            "note": None,
+        },
+        {
+            "skill": "Intimidation",
+            "ability": "charisma",
+            "value": 1,
+            "derivation": "explicit_override",
+            "note": None,
+        },
+    ]
+    payload["vitality"]["hit_points"]["displayed_average"] = 999
+    provider = FakeDefinitionProvider(payload)
+    service = _service(payload, provider=provider)
+
+    result = service.generate(_command())
+
+    assert isinstance(result, GenerateOutcomeV1)
+    definition = result.candidate.definition
+    assert definition.challenge.proficiency_bonus == 2
+    skills = {entry.skill: entry for entry in definition.proficiencies.skills}
+    assert skills["Athletics"].value == 6
+    assert skills["Intimidation"].value == 1
+    assert definition.vitality.hit_points.displayed_average == 68
+    codes = {issue.code for issue in result.candidate.validation_receipt.issues}
+    assert "SKILL_DERIVATION_MISMATCH" not in codes
+    assert "HP_DISPLAYED_AVERAGE_MISMATCH" not in codes
+    assert "RULESET_CR_PROFICIENCY_MISMATCH" not in codes

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2670,9 +2670,27 @@ def test_generate_pathological_formula_does_not_store_invalid_average(load_fixtu
 
     assert isinstance(result, GenerateOutcomeV1)
     # 1d2-2 averages -1, below displayed_average's floor: the server skips the
-    # write, the candidate stays contract-valid, and the validator flags the
-    # mismatch on the receipt instead of storing -1.
+    # write, the candidate stays contract-valid, and the receipt flags the
+    # pathological formula itself instead of storing -1.
     hit_points = result.candidate.definition.vitality.hit_points
     assert hit_points.displayed_average == 1
     codes = {issue.code for issue in result.candidate.validation_receipt.issues}
-    assert "HP_DISPLAYED_AVERAGE_MISMATCH" in codes
+    assert "HP_FORMULA_AVERAGE_INVALID" in codes
+
+
+def test_generate_pathological_formula_with_null_average_still_flags(load_fixture) -> None:
+    payload = load_fixture("simple_bruiser")
+    payload["vitality"]["hit_points"]["formula"] = {"count": 1, "die": 2, "modifier": -2}
+    payload["vitality"]["hit_points"]["displayed_average"] = None
+    provider = FakeDefinitionProvider(payload)
+    service = _service(payload, provider=provider)
+
+    result = service.generate(_command())
+
+    assert isinstance(result, GenerateOutcomeV1)
+    # With no authored average there is nothing to mismatch against, so the
+    # formula-level error is the only signal the Workbench operator gets.
+    hit_points = result.candidate.definition.vitality.hit_points
+    assert hit_points.displayed_average is None
+    codes = {issue.code for issue in result.candidate.validation_receipt.issues}
+    assert "HP_FORMULA_AVERAGE_INVALID" in codes

--- a/tests/statblocks_v1/test_generation_service.py
+++ b/tests/statblocks_v1/test_generation_service.py
@@ -2657,3 +2657,22 @@ def test_generate_server_computes_derived_values(load_fixture) -> None:
     assert "SKILL_DERIVATION_MISMATCH" not in codes
     assert "HP_DISPLAYED_AVERAGE_MISMATCH" not in codes
     assert "RULESET_CR_PROFICIENCY_MISMATCH" not in codes
+
+
+def test_generate_pathological_formula_does_not_store_invalid_average(load_fixture) -> None:
+    payload = load_fixture("simple_bruiser")
+    payload["vitality"]["hit_points"]["formula"] = {"count": 1, "die": 2, "modifier": -2}
+    payload["vitality"]["hit_points"]["displayed_average"] = 1
+    provider = FakeDefinitionProvider(payload)
+    service = _service(payload, provider=provider)
+
+    result = service.generate(_command())
+
+    assert isinstance(result, GenerateOutcomeV1)
+    # 1d2-2 averages -1, below displayed_average's floor: the server skips the
+    # write, the candidate stays contract-valid, and the validator flags the
+    # mismatch on the receipt instead of storing -1.
+    hit_points = result.candidate.definition.vitality.hit_points
+    assert hit_points.displayed_average == 1
+    codes = {issue.code for issue in result.candidate.validation_receipt.issues}
+    assert "HP_DISPLAYED_AVERAGE_MISMATCH" in codes

--- a/tests/statblocks_v1/test_import_boundaries.py
+++ b/tests/statblocks_v1/test_import_boundaries.py
@@ -49,6 +49,7 @@ STDLIB_AND_TYPING_ROOTS = {
     "pathlib",
     "copy",
     "time",
+    "logging",
 }
 
 FORBIDDEN_LEGACY = (

--- a/tests/statblocks_v1/test_prompt_builder.py
+++ b/tests/statblocks_v1/test_prompt_builder.py
@@ -27,7 +27,7 @@ def test_generation_prompt_is_versioned_definition_only() -> None:
     prompt = build_generation_prompt(command)
     system = build_system_prompt(command.ruleset.edition.value)
 
-    assert PROMPT_VERSION == "statblock-generation-prompt-v4"
+    assert PROMPT_VERSION == "statblock-generation-prompt-v5"
     assert "Gate Warden" in prompt
     assert "Guards a narrow gate." in prompt
     assert "must avoid=flight" in prompt
@@ -45,8 +45,11 @@ def test_generation_prompt_is_versioned_definition_only() -> None:
     assert "WORKED EXAMPLES" in system
     assert '"recharge_range":{"minimum":5,"maximum":6}' in system
     assert 'never the multiattack\'s own key or another multiattack' in system
-    assert '"derivation":"standard"' in system
+    assert "the server computes" in system
+    assert "the value you emit is advisory" in system
     assert "explicit_override" in system
+    # Server-owned derivation replaced arithmetic teaching in the prompt.
+    assert '"derivation":"standard"' not in system
 
 
 def test_system_prompt_examples_toggle() -> None:

--- a/tests/statblocks_v1/test_validation.py
+++ b/tests/statblocks_v1/test_validation.py
@@ -13,6 +13,7 @@ from statblocks_v1.domain import (
     validate_definition,
 )
 from statblocks_v1.domain.primitives import (
+    DiceExpression,
     Distance,
     DistanceUnit,
     RangeProfile,
@@ -548,3 +549,65 @@ def test_attack_validation_detects_inverted_range_window(load_fixture) -> None:
 
     receipt = validate_definition(mutated, ValidationMode.persistence)
     assert "ATTACK_RANGE_ORDER_INCOHERENT" in {issue.code for issue in receipt.issues}
+
+
+def _with_hit_points(definition, *, formula, displayed_average):
+    return definition.model_copy(
+        update={
+            "vitality": definition.vitality.model_copy(
+                update={
+                    "hit_points": definition.vitality.hit_points.model_copy(
+                        update={"formula": formula, "displayed_average": displayed_average}
+                    )
+                }
+            )
+        }
+    )
+
+
+def test_pathological_hp_formula_is_flagged_even_without_displayed_average(
+    load_fixture,
+) -> None:
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    mutated = _with_hit_points(
+        definition,
+        formula=DiceExpression(count=1, die=2, modifier=-2),
+        displayed_average=None,
+    )
+
+    receipt = validate_definition(mutated, ValidationMode.persistence)
+
+    codes = {issue.code for issue in receipt.issues}
+    assert "HP_FORMULA_AVERAGE_INVALID" in codes
+    assert not receipt.is_persistence_ready
+
+
+def test_pathological_hp_formula_subsumes_displayed_average_mismatch(load_fixture) -> None:
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    mutated = _with_hit_points(
+        definition,
+        formula=DiceExpression(count=1, die=2, modifier=-2),
+        displayed_average=1,
+    )
+
+    receipt = validate_definition(mutated, ValidationMode.persistence)
+
+    # The formula defect is the root cause; exactly one HP issue fires.
+    codes = {issue.code for issue in receipt.issues}
+    assert "HP_FORMULA_AVERAGE_INVALID" in codes
+    assert "HP_DISPLAYED_AVERAGE_MISMATCH" not in codes
+
+
+def test_sane_formula_keeps_displayed_average_mismatch_semantics(load_fixture) -> None:
+    definition = StatblockDefinitionV1.model_validate(load_fixture("simple_bruiser"))
+    mutated = _with_hit_points(
+        definition,
+        formula=DiceExpression(count=8, die=10, modifier=24),
+        displayed_average=50,
+    )
+
+    receipt = validate_definition(mutated, ValidationMode.persistence)
+
+    codes = {issue.code for issue in receipt.issues}
+    assert "HP_DISPLAYED_AVERAGE_MISMATCH" in codes
+    assert "HP_FORMULA_AVERAGE_INVALID" not in codes


### PR DESCRIPTION
## Summary

Stacked on #26. Answers "why are we asking an LLM to do arithmetic?" — we no longer do.

- New `statblocks_v1/domain/derived.py` owns the derivation math (CR→proficiency table, ability modifiers, standard/expertise expectations, HP average). `validation.py` now imports it instead of re-implementing, so check and compute can never drift apart.
- `GenerationServiceV1` computes server-owned values after provider parse, before validation/storage: skill/save `value` for standard/expertise (`explicit_override` keeps authored authority), `challenge.proficiency_bonus`, and `hit_points.displayed_average`. Provider numbers become advisory; overrides are logged as structured adjustments.
- `senses.passive_perception` deliberately stays authored (traits can legitimately raise it); validator semantics unchanged, so authored Workbench paths keep full error coverage.
- Prompt v5 deletes the arithmetic teaching (the derivation worked example + DERIVED MATH bullets) and replaces it with intent declaration — smaller prompt, smaller failure surface.
- Harness gains `--server-derived` to measure what production stores rather than raw model output.

## Evidence (thornvault-regent x5, arm both+ex, --server-derived)

- `gpt-5.4-mini`: `SKILL_DERIVATION_MISMATCH`, `SAVING_THROW_DERIVATION_MISMATCH`, `HP_DISPLAYED_AVERAGE_MISMATCH`, `RULESET_CR_PROFICIENCY_MISMATCH` all **0** (was 18+ derivation incidences across prior 10-trial runs on mini). The class is structurally dead regardless of model arithmetic skill.
- `gpt-5.6-luna`: 4/5 clean — matches the v4 confirmation run, no regression.
- Full lane: 299 passed, 16 skipped.

Known residuals (unchanged by this PR, tracked): mini's guidance-saturated `USAGE_FIELDS_INCOHERENT`/`SPELL_GROUP_SLOTS_INCOHERENT` clusters, and `PASSIVE_PERCEPTION_MISMATCH` is now more visible on mini since it stays authored (a candidate for the same treatment later).

## Test plan

- [x] `uv run pytest tests/statblocks_v1/ -q` (299 passed)
- [x] Harness mini + Luna runs with `--server-derived`
- [ ] After #26 merges: retarget this PR to `main`

Made with [Cursor](https://cursor.com)