### PR TITLE
STATBLOCK: keep optional explains for sealed revisions

### DIFF
--- a/statblocks_v1/domain/rule_elements.py
+++ b/statblocks_v1/domain/rule_elements.py
@@ -161,6 +161,18 @@ Mechanic = Annotated[
 ]
 
 
+class ExplainsEdge(StrictModel):
+    """Descriptive-only cross-reference; the combat engine ignores this edge.
+
+    Kept on the domain model so revisions sealed while the field existed
+    (often ``explains: []``) still load under ``extra=forbid``. New content
+    should omit the key; empty lists are legacy seal noise, not a signal.
+    """
+
+    element_key: str = Field(pattern=r"^[a-z][a-z0-9_]*$")
+    note: str | None = None
+
+
 class RuleElement(StrictModel):
     key: str = Field(pattern=r"^[a-z][a-z0-9_]*$")
     name: str = Field(min_length=1)
@@ -173,6 +185,7 @@ class RuleElement(StrictModel):
     mechanic: Mechanic
     tags: list[str] = Field(default_factory=list)
     automation_support: AutomationSupport
+    explains: list[ExplainsEdge] | None = None
 
 
 class StatblockDefinitionV1(StrictModel):

--- a/tests/statblocks_v1/test_legacy_revision_payload.py
+++ b/tests/statblocks_v1/test_legacy_revision_payload.py
@@ -1,0 +1,46 @@
+"""Legacy RuleElement.explains remains loadable for sealed revisions."""
+
+from __future__ import annotations
+
+from statblocks_v1.domain.rule_elements import ExplainsEdge, RuleElement
+
+
+def test_rule_element_accepts_legacy_empty_explains() -> None:
+    element = RuleElement.model_validate(
+        {
+            "key": "amphibious",
+            "name": "Amphibious",
+            "section": "trait",
+            "rules_text": "Can breathe air and water.",
+            "activation": {"kind": "passive"},
+            "usage": {"kind": "at_will"},
+            "mechanic": {"kind": "passive"},
+            "automation_support": "full",
+            "explains": [],
+        }
+    )
+    assert element.explains == []
+
+
+def test_rule_element_accepts_omitted_explains() -> None:
+    element = RuleElement.model_validate(
+        {
+            "key": "amphibious",
+            "name": "Amphibious",
+            "section": "trait",
+            "rules_text": "Can breathe air and water.",
+            "activation": {"kind": "passive"},
+            "usage": {"kind": "at_will"},
+            "mechanic": {"kind": "passive"},
+            "automation_support": "full",
+        }
+    )
+    assert element.explains is None
+
+
+def test_explains_edge_round_trip() -> None:
+    edge = ExplainsEdge.model_validate(
+        {"element_key": "bite", "note": "flavor only"}
+    )
+    assert edge.element_key == "bite"
+    assert edge.note == "flavor only"


### PR DESCRIPTION
## Summary
- Restore optional `RuleElement.explains` / `ExplainsEdge` so Firestore revisions sealed while the field existed still load under `extra=forbid`.
- Unblocks Latchling (`sb_7727…` / `rev_60b7…`) Threat hydration without resealing digests that World Graph bindings pin.

## Test plan
- [x] `uv run pytest tests/statblocks_v1/test_legacy_revision_payload.py`
- [x] Local GET exact revision for Latchling returns `sha256:4c843b9e…` (graph-pinned digest)
- [x] Buddy `POST /api/live/threats/query-hydration` for `threat:authored:d16d43d3…` → `available`
- [ ] Meat Mind exact revision still hydrates


Made with [Cursor](https://cursor.com)